### PR TITLE
[BE-7] feat: 스텝 공고 상세 조회 구현

### DIFF
--- a/src/main/java/guesthouse/common/annotation/UserId.java
+++ b/src/main/java/guesthouse/common/annotation/UserId.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UserId {
+    boolean required() default true;
 }

--- a/src/main/java/guesthouse/common/annotation/resolver/UserIdResolver.java
+++ b/src/main/java/guesthouse/common/annotation/resolver/UserIdResolver.java
@@ -30,20 +30,27 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
         String header = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-        String token = extractToken(header);
 
+        if (!hasToken(header)) {
+            if (isUserIdRequired(parameter)) //required가 true인데 토큰이 없으면 예외
+                throw new AuthenticationFailException();
+            return null; //required가 false이면서 토큰이 없으면 null 반환
+        }
+
+        String token = extractToken(header);
         return tokenProcessor.parseAccessToken(token);
     }
 
+    private boolean isUserIdRequired(MethodParameter parameter) {
+        UserId annotation = parameter.getParameterAnnotation(UserId.class);
+        return annotation.required();
+    }
 
-    private void validateTokenIsNull(String header) {
-        if (header == null)
-            throw new AuthenticationFailException();
+    private Boolean hasToken(String header) {
+        return header != null;
     }
 
     private String extractToken(String header) {
-        validateTokenIsNull(header);
-
         if (!header.startsWith(AUTH_TOKEN_HEADER)) {
             throw new AuthenticationFailException();
         }

--- a/src/main/java/guesthouse/staffrecruitment/controller/StaffRecruitmentController.java
+++ b/src/main/java/guesthouse/staffrecruitment/controller/StaffRecruitmentController.java
@@ -1,0 +1,29 @@
+package guesthouse.staffrecruitment.controller;
+
+import guesthouse.common.annotation.UserId;
+import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
+import guesthouse.staffrecruitment.dto.response.StaffRecruitmentDetailsResponse;
+import guesthouse.staffrecruitment.service.StaffRecruitmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/staff-recruitment")
+@RestController
+@RequiredArgsConstructor
+public class StaffRecruitmentController {
+
+    private final StaffRecruitmentService staffRecruitmentService;
+
+    @GetMapping("/{id}/details")
+    public ResponseEntity<StaffRecruitmentDetailsResponse> getDetails (
+            @PathVariable Long id,
+            @UserId (required = false)  Long userId
+    ) {
+        StaffRecruitmentDetailsDTO details= staffRecruitmentService.getDetails(id, userId);
+        return ResponseEntity.ok(StaffRecruitmentDetailsResponse.from(details));
+    }
+}

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitment.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitment.java
@@ -4,13 +4,18 @@ import guesthouse.common.domain.TimeEntity;
 import guesthouse.staffrecruitment.domain.vo.Gender;
 import guesthouse.staffrecruitment.domain.vo.Region;
 import jakarta.persistence.*;
+import lombok.*;
 import org.locationtech.jts.geom.Point;
 import guesthouse.staffrecruitment.domain.vo.WorkingPeriod;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Builder
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class StaffRecruitment extends TimeEntity {
 
     @Id
@@ -39,6 +44,8 @@ public class StaffRecruitment extends TimeEntity {
 
     @Lob
     private String content;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
     private String advantages;
     private String employeeBenefits;

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentImage.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentImage.java
@@ -2,8 +2,13 @@ package guesthouse.staffrecruitment.domain.model;
 
 import jakarta.persistence.*;
 import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentImageType;
+import lombok.*;
 
+@Builder
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class StaffRecruitmentImage {
 
     @Id
@@ -16,5 +21,7 @@ public class StaffRecruitmentImage {
     private StaffRecruitmentImageType type;
 
     private String imageUrl;
-    private String index;
+
+    @Column(name = "image_index")
+    private Long index;
 }

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentJob.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentJob.java
@@ -1,10 +1,15 @@
 package guesthouse.staffrecruitment.domain.model;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalTime;
 
+@Builder
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class StaffRecruitmentJob {
 
     @Id

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentQuestion.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentQuestion.java
@@ -4,8 +4,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StaffRecruitmentQuestion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/guesthouse/staffrecruitment/dto/StaffRecruitmentDetailsDTO.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/StaffRecruitmentDetailsDTO.java
@@ -1,0 +1,76 @@
+package guesthouse.staffrecruitment.dto;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import guesthouse.staffrecruitment.domain.vo.Gender;
+import guesthouse.staffrecruitment.domain.vo.Region;
+import guesthouse.staffrecruitment.domain.vo.WorkingPeriod;
+import lombok.Builder;
+import org.locationtech.jts.geom.Point;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record StaffRecruitmentDetailsDTO(
+        List<String> representativeImages,
+
+        String title,
+        String guesthouseName,
+        Region region,
+        String address,
+        Point coordinates,
+
+        LocalDate startDate,
+        Boolean isStartDateNegotiable,
+        WorkingPeriod workingPeriod,
+        List<StaffRecruitmentJobDTO> jobs,
+
+        String content,
+        List<String> contentImages,
+
+        Gender gender,
+        String advantages,
+        String employeeBenefits,
+
+        String instagramId,
+        String phoneNumber,
+        String email,
+        String webSite,
+        Boolean isWished,
+        String ownerMessage
+) {
+    public static StaffRecruitmentDetailsDTO from (StaffRecruitment recruitment,
+                                                   List<StaffRecruitmentJob> jobs,
+                                                   List<String> representativeImages,
+                                                   List<String> contentImages,
+                                                   Boolean isWished
+    ) {
+        return StaffRecruitmentDetailsDTO.builder()
+                .representativeImages(representativeImages)
+                .contentImages(contentImages)
+                .jobs(jobs
+                        .stream()
+                        .map(StaffRecruitmentJobDTO::from)
+                        .toList())
+                .title(recruitment.getTitle())
+                .guesthouseName(recruitment.getGuesthouseName())
+                .region(recruitment.getRegion())
+                .address(recruitment.getAddress())
+                .coordinates(recruitment.getCoordinates())
+                .startDate(recruitment.getStartDate())
+                .isStartDateNegotiable(recruitment.getIsStartDateNegotiable())
+                .workingPeriod(recruitment.getWorkingPeriod())
+                .content(recruitment.getContent())
+                .gender(recruitment.getGender())
+                .advantages(recruitment.getAdvantages())
+                .employeeBenefits(recruitment.getEmployeeBenefits())
+                .instagramId(recruitment.getInstagramId())
+                .phoneNumber(recruitment.getPhoneNumber())
+                .email(recruitment.getEmail())
+                .webSite(recruitment.getWebSite())
+                .isWished(isWished)
+                .ownerMessage(recruitment.getOwnerMessage())
+                .build();
+    }
+}

--- a/src/main/java/guesthouse/staffrecruitment/dto/StaffRecruitmentJobDTO.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/StaffRecruitmentJobDTO.java
@@ -1,0 +1,29 @@
+package guesthouse.staffrecruitment.dto;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record StaffRecruitmentJobDTO(
+        Long id,
+        String name,
+        LocalTime startTIme,
+        LocalTime endTime,
+        String job,
+        Integer workDays,
+        Integer restDays
+) {
+    public static StaffRecruitmentJobDTO from(StaffRecruitmentJob job) {
+        return StaffRecruitmentJobDTO.builder()
+                .id(job.getId())
+                .name(job.getName())
+                .startTIme(job.getStartTime())
+                .endTime(job.getEndTime())
+                .job(job.getJob())
+                .workDays(job.getWorkDays())
+                .restDays(job.getRestDays())
+                .build();
+    }
+}

--- a/src/main/java/guesthouse/staffrecruitment/dto/response/StaffRecruitmentDetailsResponse.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/response/StaffRecruitmentDetailsResponse.java
@@ -1,0 +1,133 @@
+package guesthouse.staffrecruitment.dto.response;
+
+import guesthouse.staffrecruitment.domain.vo.Gender;
+import guesthouse.staffrecruitment.domain.vo.Region;
+import guesthouse.staffrecruitment.domain.vo.WorkingPeriod;
+import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
+import guesthouse.staffrecruitment.dto.StaffRecruitmentJobDTO;
+import lombok.Builder;
+import org.locationtech.jts.geom.Point;
+
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Builder
+public record StaffRecruitmentDetailsResponse(
+        List<String> representativeImages,
+        String title,
+        String guesthouseName,
+        Region region,
+        Location location,
+        WorkingInformation workingInformation,
+        Introduction introduction,
+        Feature feature,
+        Contact contact,
+        Boolean isWished,
+        String ownerMessage
+
+) {
+    private static final String SEPARATOR = "\\|";
+
+    public static StaffRecruitmentDetailsResponse from(StaffRecruitmentDetailsDTO details) {
+        return StaffRecruitmentDetailsResponse.builder()
+                .representativeImages(details.representativeImages())
+                .title(details.title())
+                .guesthouseName(details.guesthouseName())
+                .region(details.region())
+                .location(Location.from(details.address(), details.coordinates()))
+                .workingInformation(WorkingInformation.from(details.startDate(), details.isStartDateNegotiable(), details.workingPeriod(), details.jobs()))
+                .introduction(new Introduction(details.content(), details.contentImages()))
+                .feature(Feature.from(details.gender(), details.advantages(), details.employeeBenefits()))
+                .contact(new Contact(details.instagramId(), details.phoneNumber(), details.email(), details.webSite()))
+                .isWished(details.isWished())
+                .ownerMessage(details.ownerMessage())
+                .build();
+    }
+
+    private record Location(
+            String address,
+            double[] coordinates
+    ) {
+        private static Location from(String address, Point coordinates) {
+            return new Location(
+                    address,
+                    new double[]{coordinates.getY(),  coordinates.getX()}
+            );
+        }
+    }
+
+    private record WorkingInformation(
+            LocalDate startDate,
+            Boolean isStartDateNegotiable,
+            WorkingPeriod workingPeriod,
+            List<JobSummaryDTO> jobs
+    ) {
+        private static WorkingInformation from(LocalDate startDate,
+                                               Boolean isStartDateNegotiable,
+                                               WorkingPeriod workingPeriod,
+                                               List<StaffRecruitmentJobDTO> jobs) {
+            return new WorkingInformation(
+                    startDate,
+                    isStartDateNegotiable,
+                    workingPeriod,
+                    jobs.stream()
+                            .map(JobSummaryDTO::from)
+                            .toList()
+            );
+        }
+    }
+
+    private record JobSummaryDTO(
+            String name,
+            LocalTime startTIme,
+            LocalTime endTime,
+            String job,
+            Integer workDays,
+            Integer restDays
+    ) {
+        private static JobSummaryDTO from(StaffRecruitmentJobDTO dto) {
+            return new JobSummaryDTO(
+                    dto.name(),
+                    dto.startTIme(),
+                    dto.endTime(),
+                    dto.job(),
+                    dto.workDays(),
+                    dto.restDays()
+            );
+        }
+    }
+
+    private record Introduction(
+            String content,
+            List<String> images
+    ) {
+    }
+
+    private record Feature(
+            Gender gender,
+            List<String> advantages,
+            List<String> employeeBenefits
+    ) {
+        public static Feature from(Gender gender, String advantages, String employeeBenefits) {
+            List<String> advantagesList = Arrays.asList(advantages.split(SEPARATOR));
+            List<String> employeeBenefitsList = Arrays.asList(employeeBenefits.split(SEPARATOR));
+
+            return new Feature(
+                    gender,
+                    advantagesList,
+                    employeeBenefitsList
+            );
+        }
+    }
+
+    private record Contact(
+            String instagramId,
+            String phoneNumber,
+            String email,
+            String webSite
+    ) {
+    }
+}

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentImageRepository.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentImageRepository.java
@@ -1,0 +1,13 @@
+package guesthouse.staffrecruitment.repository;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentImage;
+import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentImageType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StaffRecruitmentImageRepository extends JpaRepository<StaffRecruitmentImage,Long> {
+    List<StaffRecruitmentImage> findByStaffRecruitmentIdAndType(Long recruitmentId, StaffRecruitmentImageType staffRecruitmentImageType);
+}

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentJobRepository.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentJobRepository.java
@@ -1,0 +1,12 @@
+package guesthouse.staffrecruitment.repository;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StaffRecruitmentJobRepository extends JpaRepository<StaffRecruitmentJob,Long> {
+    List<StaffRecruitmentJob> findJobsByStaffRecruitmentId(Long id);
+}

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepository.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.staffrecruitment.repository;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StaffRecruitmentRepository extends JpaRepository<StaffRecruitment, Long> {
+}

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentService.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentService.java
@@ -1,0 +1,78 @@
+package guesthouse.staffrecruitment.service;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentImage;
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentImageType;
+import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
+import guesthouse.staffrecruitment.repository.StaffRecruitmentImageRepository;
+import guesthouse.staffrecruitment.repository.StaffRecruitmentJobRepository;
+import guesthouse.staffrecruitment.repository.StaffRecruitmentRepository;
+import guesthouse.wish.service.WishService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StaffRecruitmentService {
+
+    private final WishService wishService;
+    private final StaffRecruitmentRepository staffRecruitmentRepository;
+    private final StaffRecruitmentJobRepository staffRecruitmentJobRepository;
+    private final StaffRecruitmentImageRepository staffRecruitmentImageRepository;
+
+    @Transactional(readOnly = true)
+    public StaffRecruitmentDetailsDTO getDetails(Long id, Long userId) {
+        StaffRecruitment recruitment = getStaffRecruitmentById(id);
+        List<StaffRecruitmentJob> jobs = getJobsByRecruitmentId(id);
+        List<String> representativeImages = getRepresentativeImageUrls(id);
+        List<String> contentImages = getContentImageUrls(id);
+        Boolean isWished = isWished(id, userId);
+
+        return StaffRecruitmentDetailsDTO.from(recruitment, jobs, representativeImages, contentImages, isWished);
+    }
+
+    private Boolean isWished(Long id, Long userId) {
+        if (isGuest(userId))
+            return false;
+
+        return wishService.isWished(id, userId);
+    }
+
+    private boolean isGuest(Long userId) {
+        return userId == null;
+    }
+
+    @Transactional(readOnly = true)
+    public StaffRecruitment getStaffRecruitmentById(Long id) {
+        return staffRecruitmentRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("스태프 모집글이 존재하지 않습니다"));
+    }
+
+    @Transactional(readOnly = true)
+    public List<StaffRecruitmentJob> getJobsByRecruitmentId(Long id) {
+        return staffRecruitmentJobRepository.findJobsByStaffRecruitmentId(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getRepresentativeImageUrls(Long recruitmentId) {
+        return staffRecruitmentImageRepository.findByStaffRecruitmentIdAndType(recruitmentId, StaffRecruitmentImageType.대표이미지)
+                .stream()
+                .sorted(Comparator.comparing(StaffRecruitmentImage::getIndex))
+                .map(StaffRecruitmentImage::getImageUrl)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getContentImageUrls(Long recruitmentId) {
+        return staffRecruitmentImageRepository.findByStaffRecruitmentIdAndType(recruitmentId, StaffRecruitmentImageType.내용이미지)
+                .stream()
+                .sorted(Comparator.comparing(StaffRecruitmentImage::getIndex))
+                .map(StaffRecruitmentImage::getImageUrl)
+                .toList();
+    }
+}

--- a/src/main/java/guesthouse/wish/domain/model/Wish.java
+++ b/src/main/java/guesthouse/wish/domain/model/Wish.java
@@ -1,0 +1,23 @@
+package guesthouse.wish.domain.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Builder
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Wish {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long staffRecruitmentId;
+
+    private Long userId;
+}

--- a/src/main/java/guesthouse/wish/repository/WishRepository.java
+++ b/src/main/java/guesthouse/wish/repository/WishRepository.java
@@ -1,0 +1,10 @@
+package guesthouse.wish.repository;
+
+import guesthouse.wish.domain.model.Wish;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WishRepository extends JpaRepository<Wish, Long> {
+    Boolean existsByUserIdAndStaffRecruitmentId(Long userId, Long staffRecruitmentId);
+}

--- a/src/main/java/guesthouse/wish/service/WishService.java
+++ b/src/main/java/guesthouse/wish/service/WishService.java
@@ -1,0 +1,17 @@
+package guesthouse.wish.service;
+
+import guesthouse.wish.repository.WishRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WishService {
+    private final WishRepository wishRepository;
+
+    @Transactional(readOnly = true)
+    public Boolean isWished(Long userId, Long staffRecruitmentId) {
+        return wishRepository.existsByUserIdAndStaffRecruitmentId(userId, staffRecruitmentId);
+    }
+}


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- 스텝 공고 상세 조회 기능 및 API 구현
- 찜 여부 조회 기능 구현
- `@UserId` 어노테이션의 `resolver` 동작 로직 리팩토링
- `StaffRecruitment` 관련 엔티티들에 어노테이션 추가 (`@Getter` , `@Builder`, `@NoArgsConstructor` 등)

## 어떻게 작업했나요?
### 1. `StaffRecruitment` 관련 엔티티들의 레파지토리 구현
- `StaffRecruitmentImageRepository` , `StaffRecruitmentJobRepository`, `StaffRecruitmentRepository` 를 구현하였습니다

### 2. 찜 여부 조회 기능 구현
- 스텝 공고 상세 조회에서 찜 여부를 반환해야 하므로, 이를 위한 `Wish` 도메인 정의, `WishRepository`, `WishService`를 구현하였습니다

### 3. `UserIdResolver` 동작 로직 리팩토링
- 스텝 공고 상세 조회는 유저의 로그인 여부와 관계 없이 작동을 해야하면서, 로그인한 유저의 경우 게시글이 찜한 공고글인지에 대한 데이터를 Reseponse에 담아줘야 합니다. 그렇기에 `@UserId` 어노테이션이 사용되어야 하며, 로그인한 유저인 경우 `Id` 값을, 게스트인 경우 `null`값을 `UserId`에 넣어줘야 합니다. 따라서 `@UserId`가 사용되면서 토큰이 있는 경우에는 `id`값을, `@UserId`가 사용되면서 토큰이 없는 경우 `null`값을 반환하도록 `UserIdResolver` 동작을 리팩토링 하였습니다.

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?
 `StaffRecruitment` 관련 엔티티들에 어노테이션 몇 개를 추가해놨는데 한 번 점검해 주시기 바랍니다

## 기타 사항
`StaffRecruitment` 관련 엔티티들의 레파지토리들을 각기 구현은 하였지만, `StaffRecruitment` 관련 엔티티들의 서비스도 각기 구현해야 하는지 고민하였으나, 별도로 서비스를 만들지 않고 `StaffRecruitmentService`를 통해서 관련 엔티티들의 작업을 처리하는 게 옳다고 생각하여 `StaffRecruitmentService` 이외 별도의 서비스들은 만들지 않았습니다. 이에 대해서 어떻게 생각하시나요?

## 관련 이슈

closes #13 
