### PR TITLE
[BE-13] feat: 스탭 공고 지원 API 구현

### DIFF
--- a/src/main/java/guesthouse/application/controller/ApplicationController.java
+++ b/src/main/java/guesthouse/application/controller/ApplicationController.java
@@ -1,16 +1,18 @@
 package guesthouse.application.controller;
 
+import guesthouse.application.dto.QuestionAnswerDTO;
+import guesthouse.application.dto.requset.ApplicationApplyRequest;
 import guesthouse.application.dto.requset.ApplicationSaveRequest;
 import guesthouse.application.dto.response.ApplicationSaveResponse;
+import guesthouse.application.service.ApplicationRecordService;
 import guesthouse.application.service.ApplicationService;
 import guesthouse.common.annotation.UserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/api/v1/application")
 @RestController
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApplicationController {
 
     private final ApplicationService applicationService;
+    private final ApplicationRecordService applicationRecordService;
 
     @PostMapping
     public ResponseEntity<ApplicationSaveResponse> saveApplication(
@@ -26,5 +29,16 @@ public class ApplicationController {
     ) {
         Long applicationId = applicationService.save(applicationSaveRequest, userId);
         return ResponseEntity.ok(new ApplicationSaveResponse(applicationId));
+    }
+
+    @PostMapping("/staff-recruitment/{recruitmentId}")
+    public ResponseEntity<Void> applyForStaffRecruitment(
+            @RequestBody ApplicationApplyRequest applicationApplyRequest,
+            @PathVariable Long recruitmentId,
+            @UserId Long userId
+    ) {
+        List<QuestionAnswerDTO> answers = applicationApplyRequest.answers();
+        applicationRecordService.apply(answers, recruitmentId, userId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/guesthouse/application/domain/model/ApplicationRecord.java
+++ b/src/main/java/guesthouse/application/domain/model/ApplicationRecord.java
@@ -1,0 +1,26 @@
+package guesthouse.application.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplicationRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long staffRecruitmentId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    public ApplicationRecord(Long recruitmentId, Long userId) {
+        this.staffRecruitmentId = recruitmentId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/guesthouse/application/domain/model/ApplicationRecord.java
+++ b/src/main/java/guesthouse/application/domain/model/ApplicationRecord.java
@@ -17,10 +17,15 @@ public class ApplicationRecord {
     private Long staffRecruitmentId;
 
     @Column(nullable = false)
-    private Long applicationId;
+    private Long userId;
 
-    public ApplicationRecord(Long recruitmentId, Long applicationId) {
+    @Lob
+    @Column(nullable = false)
+    private String applicationSnapShot;
+
+    public ApplicationRecord(Long recruitmentId, Long userId, String applicationSnapShot) {
         this.staffRecruitmentId = recruitmentId;
-        this.applicationId = applicationId;
+        this.userId = userId;
+        this.applicationSnapShot = applicationSnapShot;
     }
 }

--- a/src/main/java/guesthouse/application/domain/model/ApplicationRecord.java
+++ b/src/main/java/guesthouse/application/domain/model/ApplicationRecord.java
@@ -17,10 +17,10 @@ public class ApplicationRecord {
     private Long staffRecruitmentId;
 
     @Column(nullable = false)
-    private Long userId;
+    private Long applicationId;
 
-    public ApplicationRecord(Long recruitmentId, Long userId) {
+    public ApplicationRecord(Long recruitmentId, Long applicationId) {
         this.staffRecruitmentId = recruitmentId;
-        this.userId = userId;
+        this.applicationId = applicationId;
     }
 }

--- a/src/main/java/guesthouse/application/domain/model/QuestionAnswer.java
+++ b/src/main/java/guesthouse/application/domain/model/QuestionAnswer.java
@@ -1,0 +1,31 @@
+package guesthouse.application.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long applicationRecordId;
+
+    @Column(nullable = false)
+    private Long questionId;
+
+    @Column(nullable = false)
+    private String content;
+
+    public QuestionAnswer(Long applicationRecordId, Long questionId, String content) {
+        this.applicationRecordId = applicationRecordId;
+        this.questionId = questionId;
+        this.content = content;
+    }
+}

--- a/src/main/java/guesthouse/application/domain/model/QuestionAnswer.java
+++ b/src/main/java/guesthouse/application/domain/model/QuestionAnswer.java
@@ -18,14 +18,14 @@ public class QuestionAnswer {
     private Long applicationRecordId;
 
     @Column(nullable = false)
-    private Long questionId;
+    private String question;
 
     @Column(nullable = false)
     private String content;
 
-    public QuestionAnswer(Long applicationRecordId, Long questionId, String content) {
+    public QuestionAnswer(Long applicationRecordId, String question, String content) {
         this.applicationRecordId = applicationRecordId;
-        this.questionId = questionId;
+        this.question = question;
         this.content = content;
     }
 }

--- a/src/main/java/guesthouse/application/dto/ApplicationSnapShotDTO.java
+++ b/src/main/java/guesthouse/application/dto/ApplicationSnapShotDTO.java
@@ -1,0 +1,33 @@
+package guesthouse.application.dto;
+
+import guesthouse.application.domain.model.Application;
+import guesthouse.application.domain.vo.DayOfWeek;
+import guesthouse.application.domain.vo.Mbti;
+import guesthouse.application.domain.vo.Style;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApplicationSnapShotDTO {
+
+    private LocalDate availableStartDate;
+    private Set<DayOfWeek> availableDayOfWeek;
+    private String selfIntroduction;
+    private Mbti mbti;
+    private Set<Style> style;
+
+    public static ApplicationSnapShotDTO from (Application application){
+        return ApplicationSnapShotDTO.builder()
+                .availableStartDate(application.getAvailableStartDate())
+                .availableDayOfWeek(application.getAvailableDayOfWeek())
+                .selfIntroduction(application.getSelfIntroduction())
+                .mbti(application.getMbti())
+                .style(application.getStyle())
+                .build();
+    }
+}

--- a/src/main/java/guesthouse/application/dto/QuestionAnswerDTO.java
+++ b/src/main/java/guesthouse/application/dto/QuestionAnswerDTO.java
@@ -1,0 +1,15 @@
+package guesthouse.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record QuestionAnswerDTO(
+        @Positive
+        Long questionId,
+
+        @NotNull
+        @NotBlank
+        String content
+) {
+}

--- a/src/main/java/guesthouse/application/dto/requset/ApplicationApplyRequest.java
+++ b/src/main/java/guesthouse/application/dto/requset/ApplicationApplyRequest.java
@@ -1,0 +1,12 @@
+package guesthouse.application.dto.requset;
+
+import guesthouse.application.dto.QuestionAnswerDTO;
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+public record ApplicationApplyRequest(
+        @Valid
+        List<QuestionAnswerDTO> answers
+) {
+}

--- a/src/main/java/guesthouse/application/exception/SnapShotException.java
+++ b/src/main/java/guesthouse/application/exception/SnapShotException.java
@@ -1,0 +1,6 @@
+package guesthouse.application.exception;
+
+import guesthouse.common.exception.GuestHouseException;
+
+public class SnapShotException extends GuestHouseException {
+}

--- a/src/main/java/guesthouse/application/repository/ApplicationRecordRepository.java
+++ b/src/main/java/guesthouse/application/repository/ApplicationRecordRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.application.repository;
+
+import guesthouse.application.domain.model.ApplicationRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplicationRecordRepository extends JpaRepository<ApplicationRecord,Long> {
+}

--- a/src/main/java/guesthouse/application/repository/QuestionAnswerRepository.java
+++ b/src/main/java/guesthouse/application/repository/QuestionAnswerRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.application.repository;
+
+import guesthouse.application.domain.model.QuestionAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer,Long> {
+}

--- a/src/main/java/guesthouse/application/service/ApplicationRecordService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationRecordService.java
@@ -1,5 +1,6 @@
 package guesthouse.application.service;
 
+import guesthouse.application.domain.model.Application;
 import guesthouse.application.domain.model.ApplicationRecord;
 import guesthouse.application.domain.model.QuestionAnswer;
 import guesthouse.application.dto.QuestionAnswerDTO;
@@ -17,13 +18,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ApplicationRecordService {
 
+    private final ApplicationService applicationService;
     private final StaffRecruitmentService staffRecruitmentService;
     private final ApplicationRecordRepository applicationRecordRepository;
     private final QuestionAnswerRepository questionAnswerRepository;
 
     @Transactional
     public void apply(List<QuestionAnswerDTO> answers, Long recruitmentId, Long userId) {
-        ApplicationRecord record= applicationRecordRepository.save(new ApplicationRecord(recruitmentId, userId));
+        Application application = applicationService.getApplication(userId);
+        ApplicationRecord record= applicationRecordRepository.save(new ApplicationRecord(recruitmentId, application.getId()));
         if(hasQuestions(recruitmentId)) {
             saveQuestionAnswers(answers, recruitmentId, record.getId());
         }

--- a/src/main/java/guesthouse/application/service/ApplicationRecordService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationRecordService.java
@@ -1,9 +1,13 @@
 package guesthouse.application.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import guesthouse.application.domain.model.Application;
 import guesthouse.application.domain.model.ApplicationRecord;
 import guesthouse.application.domain.model.QuestionAnswer;
+import guesthouse.application.dto.ApplicationSnapShotDTO;
 import guesthouse.application.dto.QuestionAnswerDTO;
+import guesthouse.application.exception.SnapShotException;
 import guesthouse.application.repository.ApplicationRecordRepository;
 import guesthouse.application.repository.QuestionAnswerRepository;
 import guesthouse.staffrecruitment.domain.model.StaffRecruitmentQuestion;
@@ -18,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ApplicationRecordService {
 
+    private final ObjectMapper objectMapper;
     private final ApplicationService applicationService;
     private final StaffRecruitmentService staffRecruitmentService;
     private final ApplicationRecordRepository applicationRecordRepository;
@@ -26,9 +31,20 @@ public class ApplicationRecordService {
     @Transactional
     public void apply(List<QuestionAnswerDTO> answers, Long recruitmentId, Long userId) {
         Application application = applicationService.getApplication(userId);
-        ApplicationRecord record= applicationRecordRepository.save(new ApplicationRecord(recruitmentId, application.getId()));
+        String snapShot = convertToSnapshot(application);
+
+        ApplicationRecord record= applicationRecordRepository.save(new ApplicationRecord(recruitmentId, userId, snapShot));
         if(hasQuestions(recruitmentId)) {
             saveQuestionAnswers(answers, recruitmentId, record.getId());
+        }
+    }
+
+    private String convertToSnapshot(Application application) {
+        ApplicationSnapShotDTO  snapShot = ApplicationSnapShotDTO.from(application);
+        try {
+            return objectMapper.writeValueAsString(snapShot);
+        } catch (JsonProcessingException e) {
+            throw new SnapShotException();
         }
     }
 

--- a/src/main/java/guesthouse/application/service/ApplicationRecordService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationRecordService.java
@@ -1,0 +1,46 @@
+package guesthouse.application.service;
+
+import guesthouse.application.domain.model.ApplicationRecord;
+import guesthouse.application.domain.model.QuestionAnswer;
+import guesthouse.application.dto.QuestionAnswerDTO;
+import guesthouse.application.repository.ApplicationRecordRepository;
+import guesthouse.application.repository.QuestionAnswerRepository;
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentQuestion;
+import guesthouse.staffrecruitment.service.StaffRecruitmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationRecordService {
+
+    private final StaffRecruitmentService staffRecruitmentService;
+    private final ApplicationRecordRepository applicationRecordRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+
+    @Transactional
+    public void apply(List<QuestionAnswerDTO> answers, Long recruitmentId, Long userId) {
+        ApplicationRecord record= applicationRecordRepository.save(new ApplicationRecord(recruitmentId, userId));
+        if(hasQuestions(recruitmentId)) {
+            saveQuestionAnswers(answers, recruitmentId, record.getId());
+        }
+    }
+
+    private boolean hasQuestions(Long recruitmentId) {
+        return staffRecruitmentService.hasQuestion(recruitmentId);
+    }
+
+    private void saveQuestionAnswers(List<QuestionAnswerDTO> answers, Long recruitmentId, Long recordId) {
+        answers.forEach(answer -> {
+           StaffRecruitmentQuestion question = staffRecruitmentService.getStaffRecruitmentQuestion(answer.questionId(), recruitmentId);
+           saveQuestionAnswer(recordId, question.getId(), answer.content());
+        });
+    }
+
+    private void saveQuestionAnswer(Long recordId, Long questionId, String content) {
+        questionAnswerRepository.save(new QuestionAnswer(recordId, questionId, content));
+    }
+}

--- a/src/main/java/guesthouse/application/service/ApplicationRecordService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationRecordService.java
@@ -39,11 +39,11 @@ public class ApplicationRecordService {
     private void saveQuestionAnswers(List<QuestionAnswerDTO> answers, Long recruitmentId, Long recordId) {
         answers.forEach(answer -> {
            StaffRecruitmentQuestion question = staffRecruitmentService.getStaffRecruitmentQuestion(answer.questionId(), recruitmentId);
-           saveQuestionAnswer(recordId, question.getId(), answer.content());
+           saveQuestionAnswer(recordId, question.getContent(), answer.content());
         });
     }
 
-    private void saveQuestionAnswer(Long recordId, Long questionId, String content) {
-        questionAnswerRepository.save(new QuestionAnswer(recordId, questionId, content));
+    private void saveQuestionAnswer(Long recordId, String question, String content) {
+        questionAnswerRepository.save(new QuestionAnswer(recordId, question, content));
     }
 }

--- a/src/main/java/guesthouse/application/service/ApplicationService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationService.java
@@ -32,4 +32,9 @@ public class ApplicationService {
 
         return applicationRepository.save(application).getId();
     }
+
+    public Application getApplication(Long userId) {
+        return applicationRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저의 지원서가 존재하지 않습니다"));
+    }
 }

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentQuestionsRepository.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentQuestionsRepository.java
@@ -1,0 +1,15 @@
+package guesthouse.staffrecruitment.repository;
+
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StaffRecruitmentQuestionsRepository extends JpaRepository<StaffRecruitmentQuestion, Long> {
+
+    Optional<StaffRecruitmentQuestion> findByIdAndStaffRecruitmentId(Long staffRecruitmentQuestionId, Long staffRecruitmentId);
+
+    Boolean existsByStaffRecruitmentId(Long recruitmentId);
+}

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentService.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentService.java
@@ -3,6 +3,7 @@ package guesthouse.staffrecruitment.service;
 import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
 import guesthouse.staffrecruitment.domain.model.StaffRecruitmentImage;
 import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import guesthouse.staffrecruitment.domain.model.StaffRecruitmentQuestion;
 import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentFilter;
 import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentImageType;
 import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
@@ -10,6 +11,7 @@ import guesthouse.staffrecruitment.dto.response.StaffRecruitmentPostDto;
 import guesthouse.staffrecruitment.dto.response.StaffRecruitmentPostsResponse;
 import guesthouse.staffrecruitment.repository.StaffRecruitmentImageRepository;
 import guesthouse.staffrecruitment.repository.StaffRecruitmentJobRepository;
+import guesthouse.staffrecruitment.repository.StaffRecruitmentQuestionsRepository;
 import guesthouse.staffrecruitment.repository.StaffRecruitmentRepository;
 import guesthouse.wish.service.WishService;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class StaffRecruitmentService {
@@ -29,6 +30,7 @@ public class StaffRecruitmentService {
     private final StaffRecruitmentRepository staffRecruitmentRepository;
     private final StaffRecruitmentJobRepository staffRecruitmentJobRepository;
     private final StaffRecruitmentImageRepository staffRecruitmentImageRepository;
+    private final StaffRecruitmentQuestionsRepository  staffRecruitmentQuestionsRepository;
 
     @Transactional(readOnly = true)
     public StaffRecruitmentDetailsDTO getDetails(Long id, Long userId) {
@@ -100,5 +102,14 @@ public class StaffRecruitmentService {
                 isWished(staffRecruitment.getId(), userId),
                 image.getImageUrl()
         );
+    }
+
+    public StaffRecruitmentQuestion getStaffRecruitmentQuestion(Long staffRecruitmentQuestionId, Long staffRecruitmentId) {
+        return staffRecruitmentQuestionsRepository.findByIdAndStaffRecruitmentId(staffRecruitmentQuestionId, staffRecruitmentId)
+                .orElseThrow(() -> new IllegalArgumentException("질문이 존재하지 않습니다"));
+    }
+
+    public Boolean hasQuestion(Long recruitmentId) {
+        return staffRecruitmentQuestionsRepository.existsByStaffRecruitmentId(recruitmentId);
     }
 }


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- 스탭 공고 지원 API를 구현하였습니다

## 어떻게 작업했나요?
### 1. 공고 내 질문 여부 확인, 질문 조회 기능 구현
요청으로 들어온 공고를 저장하기 앞서서, 공고에는 질문이 있을 수도 없을 수도 있습니다. 따라서 공고에 추가 질문이 없는 경우에는 그저 지원 내역만 저장하며, 추가 질문이 있는 경우에는 `Request`로 들어온 `질문id`와 `공고id`가 존재하는지 확인하여 저장을 하게 됩니다. `공고id`가 추가적으로 필요한 이유는, 혹여 지원하는 공고가 가지고 있는 `질문`과 `Request`에서 답변한 `질문`이 서로 맞지 않게 오는 잘못된 요청이 있을 수도 있다고 생각하였습니다. 

### 2. ApplicationRecord, QuestionAnswer 엔티티 구현
스탭 지원 내역을 의미하는 `ApplicationRecord`, 지원하며 유저가 질문에 답변한 내용을 `QuestionAnswer` 로 구현하였습니다. 

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?
위의 1번과 2번에 대해서 로직상 이상은 없는지, 엔티티는 잘 설계 했는지 점검 부탁드립니다

## 기타 사항

## 관련 이슈

closes #24 
