### PR TITLE
[BE-19]  reafctor: 지원서 필터링 조회 API, 지원서 상세 조회 API 리팩토링 

### DIFF
--- a/src/main/java/guesthouse/staffrecruitment/controller/StaffRecruitmentController.java
+++ b/src/main/java/guesthouse/staffrecruitment/controller/StaffRecruitmentController.java
@@ -47,15 +47,17 @@ public class StaffRecruitmentController {
             @RequestParam(defaultValue = "최신순") SortType sort,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) List<Region> region,
+            @RequestParam(required = false) WorkType workType,
+            @RequestParam(required = false) Integer workDays,
+            @RequestParam(required = false) Integer restDays,
             @RequestParam(required = false) List<WorkingPeriod> period,
             @RequestParam(required = false) List<WorkScheduleType> workScheduleType,
             @RequestParam(required = false) Gender gender,
             @RequestParam int pageNumber,
             @UserId(required = false) Long userId
     ) {
-
         StaffRecruitmentFilter filter = new StaffRecruitmentFilter(
-                keyword, sort, region, gender, period, workScheduleType
+                keyword, sort, region, workType, workDays, restDays, gender, period, workScheduleType
         );
         StaffRecruitmentPostsResponse response = staffRecruitmentService.getStaffRecruitments(userId, pageNumber, filter);
 

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentJob.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitmentJob.java
@@ -24,6 +24,8 @@ public class StaffRecruitmentJob {
     private LocalTime startTime;
     private LocalTime endTime;
     private String job;
+
+    @Enumerated(EnumType.STRING)
     private WorkType standard;
     private Integer workDays;
     private Integer restDays;

--- a/src/main/java/guesthouse/staffrecruitment/domain/vo/StaffRecruitmentFilter.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/vo/StaffRecruitmentFilter.java
@@ -12,14 +12,22 @@ public class StaffRecruitmentFilter {
     private final String keyword;
     private final SortType sortType;
     private final List<Region> region;
+    private final WorkType workType;
+    private final Integer workDays;
+    private final Integer restDays;
     private final Gender gender;
     private final List<WorkingPeriod> workingPeriods;
     private final List<WorkScheduleType> workScheduleType;
 
-    public StaffRecruitmentFilter(String keyword, SortType sortType, List<Region> region, Gender gender, List<WorkingPeriod> workingPeriods, List<WorkScheduleType> workScheduleType) {
+    public StaffRecruitmentFilter(String keyword, SortType sortType, List<Region> region,
+                                  WorkType workType, Integer workDays, Integer restDays,
+                                  Gender gender, List<WorkingPeriod> workingPeriods, List<WorkScheduleType> workScheduleType) {
         this.keyword = keyword;
         this.sortType = sortType;
         this.region = region;
+        this.workType = workType;
+        this.workDays = workDays;
+        this.restDays = restDays;
         this.gender = gender;
         this.workingPeriods = workingPeriods;
         this.workScheduleType = workScheduleType;

--- a/src/main/java/guesthouse/staffrecruitment/dto/StaffRecruitmentJobDTO.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/StaffRecruitmentJobDTO.java
@@ -1,6 +1,7 @@
 package guesthouse.staffrecruitment.dto;
 
 import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import guesthouse.staffrecruitment.domain.vo.WorkType;
 import lombok.Builder;
 
 import java.time.LocalTime;
@@ -13,7 +14,8 @@ public record StaffRecruitmentJobDTO(
         LocalTime endTime,
         String job,
         Integer workDays,
-        Integer restDays
+        Integer restDays,
+        WorkType workType
 ) {
     public static StaffRecruitmentJobDTO from(StaffRecruitmentJob job) {
         return StaffRecruitmentJobDTO.builder()
@@ -24,6 +26,7 @@ public record StaffRecruitmentJobDTO(
                 .job(job.getJob())
                 .workDays(job.getWorkDays())
                 .restDays(job.getRestDays())
+                .workType(job.getStandard())
                 .build();
     }
 }

--- a/src/main/java/guesthouse/staffrecruitment/dto/response/StaffRecruitmentDetailsResponse.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/response/StaffRecruitmentDetailsResponse.java
@@ -2,6 +2,7 @@ package guesthouse.staffrecruitment.dto.response;
 
 import guesthouse.staffrecruitment.domain.vo.Gender;
 import guesthouse.staffrecruitment.domain.vo.Region;
+import guesthouse.staffrecruitment.domain.vo.WorkType;
 import guesthouse.staffrecruitment.domain.vo.WorkingPeriod;
 import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
 import guesthouse.staffrecruitment.dto.StaffRecruitmentJobDTO;
@@ -29,7 +30,7 @@ public record StaffRecruitmentDetailsResponse(
         String ownerMessage
 
 ) {
-    private static final String SEPARATOR = "\\|";
+    private static final String SEPARATOR = "\\|:\\|";
 
     public static StaffRecruitmentDetailsResponse from(StaffRecruitmentDetailsDTO details) {
         return StaffRecruitmentDetailsResponse.builder()
@@ -86,7 +87,8 @@ public record StaffRecruitmentDetailsResponse(
             LocalTime endTime,
             String job,
             Integer workDays,
-            Integer restDays
+            Integer restDays,
+            WorkType workType
     ) {
         private static JobSummaryDTO from(StaffRecruitmentJobDTO dto) {
             return new JobSummaryDTO(
@@ -95,7 +97,8 @@ public record StaffRecruitmentDetailsResponse(
                     dto.endTime(),
                     dto.job(),
                     dto.workDays(),
-                    dto.restDays()
+                    dto.restDays(),
+                    dto.workType()
             );
         }
     }

--- a/src/main/java/guesthouse/staffrecruitment/dto/response/StaffRecruitmentDetailsResponse.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/response/StaffRecruitmentDetailsResponse.java
@@ -12,8 +12,10 @@ import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Builder
 public record StaffRecruitmentDetailsResponse(
@@ -115,14 +117,23 @@ public record StaffRecruitmentDetailsResponse(
             List<String> employeeBenefits
     ) {
         public static Feature from(Gender gender, String advantages, String employeeBenefits) {
-            List<String> advantagesList = Arrays.asList(advantages.split(SEPARATOR));
-            List<String> employeeBenefitsList = Arrays.asList(employeeBenefits.split(SEPARATOR));
+            List<String> advantagesList = splitBySeparator(advantages);
+            List<String> employeeBenefitsList = splitBySeparator(employeeBenefits);
 
             return new Feature(
                     gender,
                     advantagesList,
                     employeeBenefitsList
             );
+        }
+
+        private static List<String> splitBySeparator(String str) {
+            List<String> result = new ArrayList<>();
+
+            if (str != null && !str.isBlank())
+                result = Arrays.asList(str.split(SEPARATOR));
+
+            return result;
         }
     }
 

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
@@ -43,7 +43,6 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     }
 
     private BooleanExpression regionIn(List<Region> region) {
-        System.out.println(region);
         if (region == null || region.isEmpty()) {
             return null;
         }
@@ -51,7 +50,6 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     }
 
     private BooleanExpression workingPeriodsIn(List<WorkingPeriod> workingPeriods) {
-        System.out.println(workingPeriods);
         if (workingPeriods == null || workingPeriods.isEmpty()) {
             return null;
         }
@@ -59,33 +57,27 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     }
 
     private BooleanExpression genderEq(Gender gender) {
-        System.out.println(gender);
         return gender == null ? null : staffRecruitment.feature.gender.eq(gender);
     }
 
     private Predicate workTypeEq(WorkType workType) {
-        System.out.println(workType);
         return workType == null ? null : staffRecruitmentJob.standard.eq(workType);
     }
 
     private Predicate workDaysEq(Integer workDays) {
-        System.out.println(workDays);
         return workDays == null ? null : staffRecruitmentJob.workDays.eq(workDays);
     }
 
     private Predicate restDaysEq(Integer restDays) {
-        System.out.println(restDays);
         return restDays == null ? null : staffRecruitmentJob.restDays.eq(restDays);
     }
 
 
     private BooleanExpression keywordContains(String keyword) {
-        System.out.println(keyword);
         return keyword == null ? null : staffRecruitment.guesthouseName.contains(keyword);
     }
 
     private BooleanExpression workScheduleIn(List<WorkScheduleType> workScheduleTypes) {
-        System.out.println(workScheduleTypes);
         if (workScheduleTypes == null || workScheduleTypes.isEmpty()) {
             return null;
         }

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
@@ -1,6 +1,7 @@
 package guesthouse.staffrecruitment.repository;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -29,6 +30,9 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
                 .where(
                         regionIn(filter.getRegion()),
                         genderEq(filter.getGender()),
+                        workTypeEq(filter.getWorkType()),
+                        workDaysEq(filter.getWorkDays()),
+                        restDaysEq(filter.getRestDays()),
                         workingPeriodsIn(filter.getWorkingPeriods()),
                         workScheduleIn(filter.getWorkScheduleType()),
                         keywordContains(filter.getKeyword())
@@ -39,6 +43,7 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     }
 
     private BooleanExpression regionIn(List<Region> region) {
+        System.out.println(region);
         if (region == null || region.isEmpty()) {
             return null;
         }
@@ -46,6 +51,7 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     }
 
     private BooleanExpression workingPeriodsIn(List<WorkingPeriod> workingPeriods) {
+        System.out.println(workingPeriods);
         if (workingPeriods == null || workingPeriods.isEmpty()) {
             return null;
         }
@@ -53,14 +59,33 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     }
 
     private BooleanExpression genderEq(Gender gender) {
+        System.out.println(gender);
         return gender == null ? null : staffRecruitment.feature.gender.eq(gender);
     }
 
+    private Predicate workTypeEq(WorkType workType) {
+        System.out.println(workType);
+        return workType == null ? null : staffRecruitmentJob.standard.eq(workType);
+    }
+
+    private Predicate workDaysEq(Integer workDays) {
+        System.out.println(workDays);
+        return workDays == null ? null : staffRecruitmentJob.workDays.eq(workDays);
+    }
+
+    private Predicate restDaysEq(Integer restDays) {
+        System.out.println(restDays);
+        return restDays == null ? null : staffRecruitmentJob.restDays.eq(restDays);
+    }
+
+
     private BooleanExpression keywordContains(String keyword) {
+        System.out.println(keyword);
         return keyword == null ? null : staffRecruitment.guesthouseName.contains(keyword);
     }
 
     private BooleanExpression workScheduleIn(List<WorkScheduleType> workScheduleTypes) {
+        System.out.println(workScheduleTypes);
         if (workScheduleTypes == null || workScheduleTypes.isEmpty()) {
             return null;
         }

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentJobMapper.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentJobMapper.java
@@ -22,13 +22,6 @@ public final class StaffRecruitmentJobMapper {
     }
 
     private static StaffRecruitmentJob createStaffRecruitmentJob(Long staffRecruitmentId, StaffRecruitmentCreateRequest.Job job) {
-        Integer workDays = job.workDays();
-        Integer restDays = job.restDays();
-        if (isWeeklyStandard(job.standard())){
-            workDays = job.weeklyWorkingDays().getWorkDays();
-            restDays = SEVEN_DAYS - workDays;
-        }
-
         return StaffRecruitmentJob.builder()
                 .staffRecruitmentId(staffRecruitmentId)
                 .name(job.name())
@@ -36,13 +29,9 @@ public final class StaffRecruitmentJobMapper {
                 .endTime(job.endTime())
                 .job(job.job())
                 .standard(job.standard())
-                .workDays(workDays)
-                .restDays(restDays)
+                .workDays(job.workDays())
+                .restDays(job.restDays())
                 .workScheduleType(job.weeklyWorkingDays())
                 .build();
-    }
-
-    private static boolean isWeeklyStandard(WorkType standard) {
-        return standard == WorkType._7일_기준;
     }
 }

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentJobMapper.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentJobMapper.java
@@ -1,11 +1,13 @@
 package guesthouse.staffrecruitment.service;
 
 import guesthouse.staffrecruitment.domain.model.StaffRecruitmentJob;
+import guesthouse.staffrecruitment.domain.vo.WorkType;
 import guesthouse.staffrecruitment.dto.request.StaffRecruitmentCreateRequest;
 
 import java.util.List;
 
 public final class StaffRecruitmentJobMapper {
+    private static final Integer SEVEN_DAYS = 7;
 
     private StaffRecruitmentJobMapper() {
 
@@ -20,6 +22,13 @@ public final class StaffRecruitmentJobMapper {
     }
 
     private static StaffRecruitmentJob createStaffRecruitmentJob(Long staffRecruitmentId, StaffRecruitmentCreateRequest.Job job) {
+        Integer workDays = job.workDays();
+        Integer restDays = job.restDays();
+        if (isWeeklyStandard(job.standard())){
+            workDays = job.weeklyWorkingDays().getWorkDays();
+            restDays = SEVEN_DAYS - workDays;
+        }
+
         return StaffRecruitmentJob.builder()
                 .staffRecruitmentId(staffRecruitmentId)
                 .name(job.name())
@@ -27,9 +36,13 @@ public final class StaffRecruitmentJobMapper {
                 .endTime(job.endTime())
                 .job(job.job())
                 .standard(job.standard())
-                .workDays(job.workDays())
-                .restDays(job.restDays())
+                .workDays(workDays)
+                .restDays(restDays)
                 .workScheduleType(job.weeklyWorkingDays())
                 .build();
+    }
+
+    private static boolean isWeeklyStandard(WorkType standard) {
+        return standard == WorkType._7일_기준;
     }
 }


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- 지원서 필터링 조회 API 리팩터링
- 지원서 상세 조회 응답형태 리팩터링

## 어떻게 작업했나요?
### 1. 지원서 필터링 조회 API 리팩터링
- QueryDsl을 통한 동적 쿼리에서 `restDays`, `workDays`, `workType`을 통해서 필터링도 될 수 있게끔 수정하였습니다

### 2. 지원서 상세 조회 API 응답 형태 리팩터링
-`workingInformation` 내부 `jobs` 라는 데이터에서 `workType` 데이터를 추가하였습니다

### 3. StaffRecruitmentJobMapper의 job 생성 로직 수정
- 기존에는 `StaffRecruitmentJobMapper` 에서 job이 생성 될 때, request안에 있는 `restDays`와 `workDays`를 그대로 대입하는 로직이였습니다. 
- 하지만, 7일 기준으로 job이 생성될 경우 공고글 등록 request의 `restDays`와 `workDays`에 `null`값이 대입되는 문제가 있었습니다. 따라서 이를 해결하고자 `7일 기준`으로 job이 생성 시, 그에 맞춰서 `restDays`와 `workDays`에 값을 대입 후 job이 생성되도록 수정하였습니다.
 
## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?
QueryDsl 수정 부분이랑 StaffRecruitmentJobMapper 수정 부분을 유의깊게 봐주시면 감사하겠습니다.

## 기타 사항

## 관련 이슈

closes #37 
