### PR TITLE
[BE-21] refactor: 스탭 지원 시 한 번만 지원되도록 수정

### DIFF
--- a/src/main/java/guesthouse/application/repository/ApplicationRecordRepository.java
+++ b/src/main/java/guesthouse/application/repository/ApplicationRecordRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ApplicationRecordRepository extends JpaRepository<ApplicationRecord,Long> {
+    Boolean existsByStaffRecruitmentIdAndUserId(Long recruitmentId, Long userId);
 }

--- a/src/main/java/guesthouse/application/service/ApplicationRecordService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationRecordService.java
@@ -30,7 +30,7 @@ public class ApplicationRecordService {
 
     @Transactional
     public void apply(List<QuestionAnswerDTO> answers, Long recruitmentId, Long userId) {
-        checkNotDuplicatedApplicationRequest(recruitmentId, userId);
+        checkDuplicatedApplication(recruitmentId, userId);
         Application application = applicationService.getApplication(userId);
         String snapShot = convertToSnapshot(application);
 
@@ -40,7 +40,7 @@ public class ApplicationRecordService {
         }
     }
 
-    private void checkNotDuplicatedApplicationRequest(Long recruitmentId, Long userId) {
+    private void checkDuplicatedApplication(Long recruitmentId, Long userId) {
         Boolean isDuplicated = applicationRecordRepository.existsByStaffRecruitmentIdAndUserId(recruitmentId, userId);
         if (isDuplicated)
             throw new IllegalArgumentException("이미 지원한 스탭 공고입니다");

--- a/src/main/java/guesthouse/application/service/ApplicationRecordService.java
+++ b/src/main/java/guesthouse/application/service/ApplicationRecordService.java
@@ -30,6 +30,7 @@ public class ApplicationRecordService {
 
     @Transactional
     public void apply(List<QuestionAnswerDTO> answers, Long recruitmentId, Long userId) {
+        checkNotDuplicatedApplicationRequest(recruitmentId, userId);
         Application application = applicationService.getApplication(userId);
         String snapShot = convertToSnapshot(application);
 
@@ -37,6 +38,12 @@ public class ApplicationRecordService {
         if(hasQuestions(recruitmentId)) {
             saveQuestionAnswers(answers, recruitmentId, record.getId());
         }
+    }
+
+    private void checkNotDuplicatedApplicationRequest(Long recruitmentId, Long userId) {
+        Boolean isDuplicated = applicationRecordRepository.existsByStaffRecruitmentIdAndUserId(recruitmentId, userId);
+        if (isDuplicated)
+            throw new IllegalArgumentException("이미 지원한 스탭 공고입니다");
     }
 
     private String convertToSnapshot(Application application) {

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
@@ -74,7 +74,7 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
 
 
     private BooleanExpression keywordContains(String keyword) {
-        return keyword == null ? null : staffRecruitment.guesthouseName.contains(keyword);
+        return keyword == null ? null : staffRecruitment.guestHouseName.contains(keyword);
     }
 
     private BooleanExpression workScheduleIn(List<WorkScheduleType> workScheduleTypes) {

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentMapper.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentMapper.java
@@ -33,7 +33,7 @@ public final class StaffRecruitmentMapper {
         return StaffRecruitment.builder()
                 .ownerId(ownerId)
                 .title(request.title())
-                .guesthouseName(request.guestHouseName())
+                .guestHouseName(request.guestHouseName())
                 .region(request.region())
                 .lotNumberAddress(location.lotNumberAddress())
                 .roadNameAddress(location.roadNameAddress())


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- 스탭 지원 시 한 번만 지원할 수 있도록 스탭 공고 지원 로직을 수정하였습니다
- `guestHouse`로 되어있지 않은 일부 변수명들을 수정하였습니다

## 어떻게 작업했나요?
- 스탭 지원 시 `StaffRecruitmentId` 와 `UserId`를 기반으로 `ApplicationRecord`가 존재하는지 확인한 후, 존재한다면 에러가 발생하게끔 하였습니다

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?

## 기타 사항

## 관련 이슈

closes #41 
