### PR TITLE
[BE-23] feat: 게스트하우스 도메인 Entity 구현

### DIFF
--- a/src/main/java/guesthouse/guestHousePost/domain/model/Amenity.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Amenity.java
@@ -1,0 +1,22 @@
+package guesthouse.guestHousePost.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Amenity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String value;
+
+    @Column(nullable = false)
+    private Long guestHousePostId;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
@@ -1,0 +1,56 @@
+package guesthouse.guestHousePost.domain.model;
+
+import guesthouse.guestHousePost.domain.vo.Contact;
+import guesthouse.guestHousePost.domain.vo.Mood;
+import guesthouse.staffrecruitment.domain.vo.Region;
+import jakarta.persistence.*;
+import lombok.*;
+import org.locationtech.jts.geom.Point;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GuestHousePost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String guestHouseName;
+
+    @Enumerated(EnumType.STRING)
+    private Region region;
+
+    @Column(nullable = false)
+    private String lotNumberAddress;
+
+    @Column(nullable = false)
+    private String roadNameAddress;
+
+    @Column(columnDefinition = "POINT SRID 4326", nullable = false)
+    private Point coordinates;
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+    @ElementCollection
+    @JoinTable(
+            name = "mood",
+            joinColumns = @JoinColumn(name="guest_house_post_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "value")
+    private Set<Mood> moods = new HashSet<>();
+
+    @Embedded
+    private Contact contact;
+
+    @Column(nullable = false)
+    private String ownerMessage;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePostImage.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePostImage.java
@@ -1,0 +1,29 @@
+package guesthouse.guestHousePost.domain.model;
+
+import guesthouse.guestHousePost.domain.vo.ImageType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GuestHousePostImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long guestHousePostId;
+
+    @Enumerated(EnumType.STRING)
+    private ImageType type;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(name = "image_index")
+    private int index;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePostImage.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePostImage.java
@@ -1,6 +1,5 @@
 package guesthouse.guestHousePost.domain.model;
 
-import guesthouse.guestHousePost.domain.vo.ImageType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,9 +16,6 @@ public class GuestHousePostImage {
 
     @Column(nullable = false)
     private Long guestHousePostId;
-
-    @Enumerated(EnumType.STRING)
-    private ImageType type;
 
     @Column(nullable = false)
     private String imageUrl;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -1,6 +1,7 @@
 package guesthouse.guestHousePost.domain.model;
 
 import guesthouse.application.domain.vo.DayOfWeek;
+import guesthouse.guestHousePost.domain.vo.PartyType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,6 +22,9 @@ public class Party {
 
     @Column(nullable = false)
     private Long GuestHousePostId;
+
+    @Column(nullable = false)
+    private PartyType partyType;
 
     @Column(nullable = false)
     private LocalTime startTime;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -1,0 +1,57 @@
+package guesthouse.guestHousePost.domain.model;
+
+import guesthouse.application.domain.vo.DayOfWeek;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Party {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long GuestHousePostId;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    @ElementCollection
+    @JoinTable(
+            name = "weekly_day",
+            joinColumns = @JoinColumn(name="party_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "value")
+    private Set<DayOfWeek> weeklyDays = new HashSet<>();
+
+    @Column(nullable = false)
+    private String place;
+
+    @Column(nullable = false)
+    private String moods;
+
+    @Column(nullable = false)
+    private Boolean isExternalGuestAllowed;
+
+    @Column(nullable = false)
+    private Long guestFee;
+
+    @Column(nullable = false)
+    private Long externalGuestFee;
+
+    @Column(columnDefinition = "TEXT")
+    private String information;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/PartyImage.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/PartyImage.java
@@ -1,0 +1,29 @@
+package guesthouse.guestHousePost.domain.model;
+
+import guesthouse.guestHousePost.domain.vo.ImageType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PartyImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long partyId;
+
+    @Enumerated(EnumType.STRING)
+    private ImageType type;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(name = "image_index")
+    private int index;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/PartyImage.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/PartyImage.java
@@ -1,6 +1,5 @@
 package guesthouse.guestHousePost.domain.model;
 
-import guesthouse.guestHousePost.domain.vo.ImageType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,9 +16,6 @@ public class PartyImage {
 
     @Column(nullable = false)
     private Long partyId;
-
-    @Enumerated(EnumType.STRING)
-    private ImageType type;
 
     @Column(nullable = false)
     private String imageUrl;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Room.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Room.java
@@ -19,7 +19,7 @@ public class Room {
     private Long id;
 
     @Column(nullable = false)
-    private Long GuestHousePostId;
+    private Long guestHousePostId;
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Room.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Room.java
@@ -39,5 +39,5 @@ public class Room {
     private LocalTime checkOutTime;
 
     @Column(nullable = false)
-    private Long pricePerNight;
+    private Integer pricePerNight;
 }

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Room.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Room.java
@@ -1,0 +1,43 @@
+package guesthouse.guestHousePost.domain.model;
+
+import guesthouse.guestHousePost.domain.vo.RoomHeadCount;
+import guesthouse.guestHousePost.domain.vo.RoomType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long GuestHousePostId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoomType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoomHeadCount headCount;
+
+    @Column(nullable = false)
+    private LocalTime checkInTime;
+
+    @Column(nullable = false)
+    private LocalTime checkOutTime;
+
+    @Column(nullable = false)
+    private Long pricePerNight;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/RoomImage.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/RoomImage.java
@@ -1,6 +1,5 @@
 package guesthouse.guestHousePost.domain.model;
 
-import guesthouse.guestHousePost.domain.vo.ImageType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,9 +16,6 @@ public class RoomImage {
 
     @Column(nullable = false)
     private Long roomId;
-
-    @Enumerated(EnumType.STRING)
-    private ImageType type;
 
     @Column(nullable = false)
     private String imageUrl;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/RoomImage.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/RoomImage.java
@@ -1,0 +1,29 @@
+package guesthouse.guestHousePost.domain.model;
+
+import guesthouse.guestHousePost.domain.vo.ImageType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RoomImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long roomId;
+
+    @Enumerated(EnumType.STRING)
+    private ImageType type;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(name = "image_index")
+    private int index;
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/Contact.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/Contact.java
@@ -1,0 +1,24 @@
+package guesthouse.guestHousePost.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class Contact {
+
+    private String instagramId;
+    private String phoneNumber;
+    private String webSite;
+
+    public Contact(String instagramId, String phoneNumber, String webSite) {
+        this.instagramId = instagramId;
+        this.phoneNumber = phoneNumber;
+        this.webSite = webSite;
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/ImageType.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/ImageType.java
@@ -1,0 +1,6 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum ImageType {
+    대표이미지,
+    내용이미지
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/Mood.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/Mood.java
@@ -1,0 +1,12 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum Mood {
+    조용한,
+    사교적,
+    힐링,
+    사색,
+    활발한,
+    잔잔한,
+    감성,
+    휴식
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/PartyType.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/PartyType.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum PartyType {
+    술파티,
+    포틀럭,
+    디너_파티,
+    클럽_파티,
+    기타
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/RoomHeadCount.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/RoomHeadCount.java
@@ -1,0 +1,7 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum RoomHeadCount {
+    _1인실,
+    _2인실,
+    _3인이상
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/RoomType.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/RoomType.java
@@ -1,0 +1,6 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum RoomType {
+    여성_전용_도미토리,
+    남성_전용_도미토리
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/RoomType.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/RoomType.java
@@ -1,6 +1,6 @@
 package guesthouse.guestHousePost.domain.vo;
 
 public enum RoomType {
-    여성_전용_도미토리,
-    남성_전용_도미토리
+    여성전용,
+    남성전용
 }


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- 게스트하우스 게시글 도메인 Entity를 구현하였습니다. (크게 GuestHousePost, Party, Room으로 나누어서 구현하였습니다)

## 어떻게 작업했나요?
### 1. GuestHousePost
- GuestHousePost에서 `Amenity`는 별도의 Entity로 만들었습니다. `enum`으로 해볼까 했지만, 사용자가 정해진 종류 말고도 추가적으로 입력할 수 있는 상황이기에 entity화 시켰습니다.
- 게스트 하우스 분위기에 해당되는 `Mood`를 `@ElementCollection` 으로 구현하였습니다. 이는 하나의 게스트 하우스에 매칭되는 분위기가 최대 2개밖에 안되기에 별도로 엔티티로 뽑아내는 것보단 `@ElementCollection` 으로 관리하는게 좋아보여서 이렇게 하였습니다. 
- GuestHousePost의 이미지를 `GuestHousePostImage`라는 별도의 엔티티로 분리하여 저장되게끔 하였습니다

### 2. Room
- Room의 이미지를 `RoomImage`라는 별도의 엔티티로 분리하여 저장되게끔 하였습니다

### 3. Party
- Party의 이미지를 `PartyImage`라는 별도의 엔티티로 분리하여 저장되게끔 하였습니다
- Party를 등록할 때 `mood`는 사용자가 자유롭게 입력할 수 있게 되어있습니다. 따라서 여러개의 파티 분위기를 입력할 때 별도의 테이블로 관리하는 게 아닌, `구분자를 통한 하나의 문자열에 저장`방식으로 관리하는 게 좋다고 판단하여 `String` 타입으로 저장되게끔 하였습니다.

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?
GuestHousePost, Party, Room 세 부분을 중점적으로 봐주시기 바랍니다.

## 기타 사항
1. `@ElementCollection`으로 저장되는 부분들이 존재하는데 이에 대해서 어떻게 생각하는지 궁금합니다
2. Party의 `mood` 값을 저장할 때 더 좋은 방법이 있을 지 궁금합니다.

## 관련 이슈

closes #44 
