### PR TITLE
[BE-25] feat: 게스트하우스 게시글 등록 API 구현

### DIFF
--- a/src/main/java/guesthouse/guestHousePost/controller/GuestHousePostController.java
+++ b/src/main/java/guesthouse/guestHousePost/controller/GuestHousePostController.java
@@ -1,0 +1,30 @@
+package guesthouse.guestHousePost.controller;
+
+import guesthouse.common.annotation.UserId;
+import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
+import guesthouse.guestHousePost.dto.response.GuestHouseCreateResponse;
+import guesthouse.guestHousePost.service.GuestHousePostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/guest-houses")
+@RestController
+@RequiredArgsConstructor
+public class GuestHousePostController {
+
+    private final GuestHousePostService guestHousePostService;
+
+    @PostMapping
+    public ResponseEntity<GuestHouseCreateResponse> createGuestHousePost(
+            @RequestBody @Valid GuestHouseCreateRequest request,
+            @UserId Long userId
+    ) {
+        Long guestHouseId = guestHousePostService.create(request, userId);
+        return ResponseEntity.ok(new GuestHouseCreateResponse(guestHouseId));
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
@@ -51,6 +51,5 @@ public class GuestHousePost {
     @Embedded
     private Contact contact;
 
-    @Column(nullable = false)
     private String ownerMessage;
 }

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -26,6 +26,8 @@ public class Party {
     @Column(nullable = false)
     private PartyType partyType;
 
+    private String otherPartyType;
+
     @Column(nullable = false)
     private LocalTime startTime;
 

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -21,7 +21,7 @@ public class Party {
     private Long id;
 
     @Column(nullable = false)
-    private Long GuestHousePostId;
+    private Long guestHousePostId;
 
     @Column(nullable = false)
     private PartyType partyType;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -1,6 +1,6 @@
 package guesthouse.guestHousePost.domain.model;
 
-import guesthouse.application.domain.vo.DayOfWeek;
+import guesthouse.guestHousePost.domain.vo.DayOfWeek;
 import guesthouse.guestHousePost.domain.vo.PartyType;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -23,6 +23,7 @@ public class Party {
     @Column(nullable = false)
     private Long guestHousePostId;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PartyType partyType;
 

--- a/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/Party.java
@@ -53,7 +53,6 @@ public class Party {
     @Column(nullable = false)
     private Long guestFee;
 
-    @Column(nullable = false)
     private Long externalGuestFee;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/DayOfWeek.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/DayOfWeek.java
@@ -1,0 +1,11 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum DayOfWeek {
+    월,
+    화,
+    수,
+    목,
+    금,
+    토,
+    일
+}

--- a/src/main/java/guesthouse/guestHousePost/dto/request/GuestHouseCreateRequest.java
+++ b/src/main/java/guesthouse/guestHousePost/dto/request/GuestHouseCreateRequest.java
@@ -1,0 +1,156 @@
+package guesthouse.guestHousePost.dto.request;
+
+import guesthouse.guestHousePost.domain.vo.*;
+import guesthouse.staffrecruitment.domain.vo.Region;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import org.hibernate.validator.constraints.Length;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+
+
+public record GuestHouseCreateRequest (
+
+        @NotBlank
+        @Length(min = 2, max = 30)
+        String guestHouseName,
+
+        @NotNull
+        Region region,
+
+        @Valid
+        @NotNull
+        Location location,
+
+        @NotEmpty
+        @Size(min = 1, max = 10)
+        List<String> imageUrls,
+
+        @NotBlank
+        @Length(min = 10, max = 500)
+        String introduction,
+
+        @NotEmpty
+        @Size(min = 1, max = 10)
+        List<@Length(min = 1, max = 20) String> amenities,
+
+        @NotEmpty
+        @Size(min = 1, max = 2)
+        Set<Mood> moods,
+
+        @Valid
+        @Size(min = 0, max = 10)
+        List<Party> parties,
+
+        @Valid
+        @Size(min = 1, max =  10)
+        List<Room> rooms,
+
+        @Valid
+        Contact contact,
+
+        @Length(max = 50)
+        String ownerMessage
+
+) {
+
+    public record Location(
+
+            @NotBlank
+            String lotNumberAddress,
+
+            @NotBlank
+            String roadNameAddress,
+
+            @Size(min = 2, max = 2)
+            List<Double> coordinates
+    ) {
+    }
+
+    public record Party (
+
+            @NotNull
+            PartyType type,
+
+            @Length (min = 1, max = 20)
+            String otherPartyType,
+
+            @NotEmpty
+            @Size(min = 1, max = 10)
+            List<String> imageUrls,
+
+            @NotNull
+            LocalTime startTime,
+
+            @NotNull
+            LocalTime endTime,
+
+            @NotEmpty
+            Set<DayOfWeek> weeklyDays,
+
+            @NotBlank
+            @Length(min = 1, max = 20)
+            String place,
+
+            @NotEmpty
+            List<@Length( min = 1, max = 20) String> moods,
+
+            @NotNull
+            Boolean isExternalGuestAllowed,
+
+            @NotNull
+            @PositiveOrZero
+            Long guestFee,
+
+            @PositiveOrZero
+            Long externalGuestFee,
+
+            @NotBlank
+            @Length(min = 10, max = 500)
+            String information
+    ) {
+    }
+
+    public record Room(
+
+            @NotBlank
+            @Length (min = 1, max = 20)
+            String name,
+
+            @NotNull
+            RoomType type,
+
+            @NotNull
+            RoomHeadCount headCountType,
+
+            @NotNull
+            LocalTime checkInTime,
+
+            @NotNull
+            LocalTime checkOutTime,
+
+            @NotNull
+            @PositiveOrZero
+            Integer pricePerNight,
+
+            @NotEmpty
+            @Size(min = 1, max = 10)
+            List<String> imageUrls
+    ) {
+    }
+
+    public record Contact(
+
+            @Length(min = 11, max = 13)
+            String phoneNumber,
+
+            @Length(min = 2, max = 30)
+            String instagramId,
+
+            @Length(max = 100)
+            String webSite
+    ) {
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/dto/response/GuestHouseCreateResponse.java
+++ b/src/main/java/guesthouse/guestHousePost/dto/response/GuestHouseCreateResponse.java
@@ -1,0 +1,6 @@
+package guesthouse.guestHousePost.dto.response;
+
+public record GuestHouseCreateResponse(
+        Long guestHouseId
+){
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/AmenityRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/AmenityRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.Amenity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AmenityRepository extends JpaRepository<Amenity, Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostImageRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostImageRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.GuestHousePostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuestHousePostImageRepository extends JpaRepository<GuestHousePostImage, Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.GuestHousePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuestHousePostRepository extends JpaRepository<GuestHousePost,Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/PartyImageRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/PartyImageRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.PartyImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PartyImageRepository extends JpaRepository<PartyImage,Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/PartyRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/PartyRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.Party;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PartyRepository extends JpaRepository<Party,Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/RoomImageRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/RoomImageRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.RoomImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomImageRepository extends JpaRepository<RoomImage, Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/repository/RoomRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/RoomRepository.java
@@ -1,0 +1,9 @@
+package guesthouse.guestHousePost.repository;
+
+import guesthouse.guestHousePost.domain.model.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends JpaRepository<Room,Long> {
+}

--- a/src/main/java/guesthouse/guestHousePost/service/AmenityMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/AmenityMapper.java
@@ -1,0 +1,26 @@
+package guesthouse.guestHousePost.service;
+
+import guesthouse.guestHousePost.domain.model.Amenity;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+
+@UtilityClass
+public class AmenityMapper {
+
+    public static List<Amenity> toAmenities(List<String> amenities, Long guestHousePostId) {
+        return amenities
+                .stream()
+                .map(value -> createdAmenities(value, guestHousePostId))
+                .toList();
+    }
+
+    private static Amenity createdAmenities(String value, Long guestHousePostId) {
+        return Amenity.builder()
+                .value(value)
+                .guestHousePostId(guestHousePostId)
+                .build();
+    }
+
+
+}

--- a/src/main/java/guesthouse/guestHousePost/service/AmenityMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/AmenityMapper.java
@@ -11,11 +11,11 @@ public class AmenityMapper {
     public static List<Amenity> toAmenities(List<String> amenities, Long guestHousePostId) {
         return amenities
                 .stream()
-                .map(value -> createdAmenities(value, guestHousePostId))
+                .map(value -> createAmenities(value, guestHousePostId))
                 .toList();
     }
 
-    private static Amenity createdAmenities(String value, Long guestHousePostId) {
+    private static Amenity createAmenities(String value, Long guestHousePostId) {
         return Amenity.builder()
                 .value(value)
                 .guestHousePostId(guestHousePostId)

--- a/src/main/java/guesthouse/guestHousePost/service/GuestHouseMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/GuestHouseMapper.java
@@ -1,0 +1,47 @@
+package guesthouse.guestHousePost.service;
+
+import guesthouse.guestHousePost.domain.model.GuestHousePost;
+import guesthouse.guestHousePost.domain.vo.Contact;
+import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
+import lombok.experimental.UtilityClass;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+import java.util.List;
+import java.util.Objects;
+
+@UtilityClass
+public class GuestHouseMapper {
+
+    public static GuestHousePost toPost(GuestHouseCreateRequest request, Long userId) {
+        GuestHouseCreateRequest.Location location = request.location();
+        GuestHouseCreateRequest.Contact contact = request.contact();
+
+        return GuestHousePost.builder()
+                .guestHouseName(request.guestHouseName())
+                .region(request.region())
+                .lotNumberAddress(location.lotNumberAddress())
+                .roadNameAddress(location.roadNameAddress())
+                .coordinates(createPoint(location.coordinates()))
+                .introduction(request.introduction())
+                .moods(request.moods())
+                .contact(createContact(contact))
+                .ownerMessage(request.ownerMessage())
+                .build();
+    }
+
+    private static Point createPoint(List<Double> coordinates) {
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        return geometryFactory.createPoint(new Coordinate(coordinates.getFirst(), coordinates.getLast()));
+    }
+
+    private static Contact createContact(GuestHouseCreateRequest.Contact contact) {
+        return new Contact(
+                Objects.requireNonNullElse(contact.instagramId(), ""),
+                Objects.requireNonNullElse(contact.phoneNumber(), ""),
+                Objects.requireNonNullElse(contact.webSite(), "")
+        );
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/service/GuestHousePostService.java
+++ b/src/main/java/guesthouse/guestHousePost/service/GuestHousePostService.java
@@ -1,0 +1,61 @@
+package guesthouse.guestHousePost.service;
+
+import guesthouse.guestHousePost.domain.model.*;
+import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
+import guesthouse.guestHousePost.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GuestHousePostService {
+
+    private final AmenityRepository amenityRepository;
+    private final GuestHousePostRepository guestHousePostRepository;
+    private final GuestHousePostImageRepository guestHousePostImageRepository;
+    private final PartyRepository partyRepository;
+    private final PartyImageRepository partyImageRepository;
+    private final RoomRepository roomRepository;
+    private final RoomImageRepository roomImageRepository;
+
+    @Transactional
+    public Long create(GuestHouseCreateRequest request, Long userId) {
+        GuestHousePost post = GuestHouseMapper.toPost(request, userId);
+        guestHousePostRepository.save(post);
+        Long postId = post.getId();
+
+        List<GuestHousePostImage> postImages = ImageMapper.toGuestHousePostImages(request.imageUrls(), postId);
+        guestHousePostImageRepository.saveAll(postImages);
+
+        List<Amenity> amenities = AmenityMapper.toAmenities(request.amenities(), postId);
+        amenityRepository.saveAll(amenities);
+
+        saveParties(request.parties(), postId);
+        saveRooms(request.rooms(), postId);
+
+        return postId;
+    }
+
+    private void saveParties(List<GuestHouseCreateRequest.Party> parties, Long postId) {
+        parties
+                .forEach(party -> {
+                    Party partyEntity = PartyMapper.toParty(party, postId);
+                    partyRepository.save(partyEntity);
+                    List<PartyImage> partyImages = ImageMapper.toPartyImage(party.imageUrls(), partyEntity.getId());
+                    partyImageRepository.saveAll(partyImages);
+                });
+    }
+
+    private void saveRooms(List<GuestHouseCreateRequest.Room> rooms, Long postId) {
+        rooms
+                .forEach(room -> {
+                    Room roomEntity = RoomMapper.toRoom(room, postId);
+                    roomRepository.save(roomEntity);
+                    List<RoomImage> roomImages = ImageMapper.toRoomImage(room.imageUrls(), roomEntity.getId());
+                    roomImageRepository.saveAll(roomImages);
+                });
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/service/ImageMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/ImageMapper.java
@@ -1,0 +1,58 @@
+package guesthouse.guestHousePost.service;
+
+import guesthouse.guestHousePost.domain.model.GuestHousePostImage;
+import guesthouse.guestHousePost.domain.model.PartyImage;
+import guesthouse.guestHousePost.domain.model.RoomImage;
+import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@UtilityClass
+public class ImageMapper {
+
+    public static List<GuestHousePostImage> toGuestHousePostImages(List<String> imageUrls, Long guestHousePostId) {
+        return IntStream.range(0, imageUrls.size())
+                .mapToObj(index -> createGuestHousePostImage(imageUrls.get(index), guestHousePostId, index))
+                .toList();
+    }
+
+    private static GuestHousePostImage createGuestHousePostImage(String imageUrl, Long guestHousePostId, int index) {
+        return GuestHousePostImage.builder()
+                .guestHousePostId(guestHousePostId)
+                .imageUrl(imageUrl)
+                .index(index)
+                .build();
+    }
+
+    public static List<PartyImage> toPartyImage(List<String> imageUrls, Long partyId) {
+        return IntStream.range(0, imageUrls.size())
+                .mapToObj(index -> createPartyImage(imageUrls.get(index), partyId, index))
+                .toList();
+    }
+
+    private static PartyImage createPartyImage(String imageUrl, Long partyId, int index) {
+        return PartyImage.builder()
+                .partyId(partyId)
+                .imageUrl(imageUrl)
+                .index(index)
+                .build();
+    }
+
+    public static List<RoomImage> toRoomImage(List<String> imageUrls, Long roomId) {
+        return IntStream.range(0, imageUrls.size())
+                .mapToObj(index -> createRoomImage(imageUrls.get(index), roomId, index))
+                .toList();
+    }
+
+    private static RoomImage createRoomImage(String imageUrl, Long roomId, int index) {
+        return RoomImage.builder()
+                .roomId(roomId)
+                .imageUrl(imageUrl)
+                .index(index)
+                .build();
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/service/PartyMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/PartyMapper.java
@@ -1,0 +1,36 @@
+package guesthouse.guestHousePost.service;
+
+import guesthouse.guestHousePost.domain.model.Party;
+import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+
+@UtilityClass
+public class PartyMapper {
+
+    public static final String DELIMITER = "|:|";
+
+    public static Party toParty(GuestHouseCreateRequest.Party party, Long guestHousePostId) {
+        return Party.builder()
+                .guestHousePostId(guestHousePostId)
+                .partyType(party.type())
+                .otherPartyType(party.otherPartyType())
+                .startTime(party.startTime())
+                .endTime(party.endTime())
+                .weeklyDays(party.weeklyDays())
+                .place(party.place())
+                .moods(createMoods(party.moods()))
+                .isExternalGuestAllowed(party.isExternalGuestAllowed())
+                .guestFee(party.guestFee())
+                .externalGuestFee(party.externalGuestFee())
+                .information(party.information())
+                .build();
+    }
+
+    private static String createMoods(List<String> moods) {
+        return String.join(DELIMITER, moods);
+
+    }
+
+}

--- a/src/main/java/guesthouse/guestHousePost/service/RoomMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/RoomMapper.java
@@ -1,0 +1,21 @@
+package guesthouse.guestHousePost.service;
+
+import guesthouse.guestHousePost.domain.model.Room;
+import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RoomMapper {
+
+    public static Room toRoom(GuestHouseCreateRequest.Room room, Long guestHousePostId) {
+        return Room.builder()
+                .guestHousePostId(guestHousePostId)
+                .name(room.name())
+                .type(room.type())
+                .headCount(room.headCountType())
+                .checkInTime(room.checkInTime())
+                .checkOutTime(room.checkInTime())
+                .pricePerNight(room.pricePerNight())
+                .build();
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/service/RoomMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/RoomMapper.java
@@ -14,7 +14,7 @@ public class RoomMapper {
                 .type(room.type())
                 .headCount(room.headCountType())
                 .checkInTime(room.checkInTime())
-                .checkOutTime(room.checkInTime())
+                .checkOutTime(room.checkOutTime())
                 .pricePerNight(room.pricePerNight())
                 .build();
     }


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- 게스트하우스 게시글 등록 API를 구현하였습니다

## 어떻게 작업했나요?
- `Party`, `GuestHousePost` 엔티티의 필드 추가와 DB 옵션을 수정하였습니다
- `Mapper` 클래스를 통해 `GuestHousPost`, `Room`, `Party`, `3개의 도메인에서 쓰이는 이미지들` 을 각기 저장할 수 있도록 구현하였습니다

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?
- RequestDTO 구조가 잘 맞는지, 서비스 코드에서 로직이 이상한 부분은 없는지 봐주시면 감사하겠습니다.

## 기타 사항
- `Room`과 `Party`의 이미지 데이터를 저장할 때 한번의 쿼리로 모든 이미지 데이터를 저장하는게 아닌, 각 `Room`과 `Party`를 저장 시 하나씩 순회하면서 `엔티티 저장` , `이미지 데이터 저장`이 일어납니다. 이러한 이유는, 두 엔티티가 하나의 request에서 하나만 존재하는게 아닌 여러개가 존재할 수 있다보니, 엔티티 저장과 이미지 데이터 저장은 같이 이루어져야 하기에 각기 `Room`과 `Party`를 저장 시 순회하면서 각마다 저장이 이루어집니다.

## 관련 이슈

closes #47 
