### PR TITLE
[BE-35] feat: 게스트하우스 게시글, 스탭 모집글 비활성화/활성화 API 구현 

### DIFF
--- a/src/main/java/guesthouse/certificate/repository/CertificateRepository.java
+++ b/src/main/java/guesthouse/certificate/repository/CertificateRepository.java
@@ -1,6 +1,5 @@
 package guesthouse.certificate.repository;
 
-import guesthouse.application.domain.model.ApplicationRecord;
 import guesthouse.certificate.domain.model.Certificate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/guesthouse/guestHousePost/controller/GuestHousePostController.java
+++ b/src/main/java/guesthouse/guestHousePost/controller/GuestHousePostController.java
@@ -5,6 +5,7 @@ import guesthouse.guestHousePost.domain.vo.*;
 import guesthouse.guestHousePost.dto.GuestHousePostDetailsDTO;
 import guesthouse.guestHousePost.dto.GuestHousePostsResponse;
 import guesthouse.guestHousePost.dto.RandomGuestHousePostsResponse;
+import guesthouse.guestHousePost.dto.request.ChangeStatusRequest;
 import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
 import guesthouse.guestHousePost.dto.response.GuestHouseCreateResponse;
 import guesthouse.guestHousePost.dto.response.GuestHousePostDetailsResponse;
@@ -81,5 +82,15 @@ public class GuestHousePostController {
     public ResponseEntity<OwnerGuestHousePostsResponse> getOwnGuestHousePosts(@UserId Long userId) {
         OwnerGuestHousePostsResponse response = guestHousePostService.getOwnGuestHousePosts(userId);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> changeStatus(
+            @RequestBody ChangeStatusRequest changeStatusRequest,
+            @UserId Long userId,
+            @PathVariable("id") Long guestHousePostId
+    ) {
+        guestHousePostService.changeStatus(changeStatusRequest.status(), userId, guestHousePostId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
@@ -2,6 +2,7 @@ package guesthouse.guestHousePost.domain.model;
 
 import guesthouse.guestHousePost.domain.vo.Contact;
 import guesthouse.guestHousePost.domain.vo.Mood;
+import guesthouse.guestHousePost.domain.vo.Status;
 import guesthouse.staffrecruitment.domain.vo.Region;
 import jakarta.persistence.*;
 import lombok.*;
@@ -55,4 +56,6 @@ public class GuestHousePost {
     private Contact contact;
 
     private String ownerMessage;
+
+    private Status status;
 }

--- a/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/model/GuestHousePost.java
@@ -57,5 +57,11 @@ public class GuestHousePost {
 
     private String ownerMessage;
 
+    @Enumerated(EnumType.STRING)
     private Status status;
+
+
+    public void changeStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/guesthouse/guestHousePost/domain/vo/Status.java
+++ b/src/main/java/guesthouse/guestHousePost/domain/vo/Status.java
@@ -1,0 +1,7 @@
+package guesthouse.guestHousePost.domain.vo;
+
+public enum Status {
+    ACTIVE,
+    INACTIVE
+}
+

--- a/src/main/java/guesthouse/guestHousePost/dto/request/ChangeStatusRequest.java
+++ b/src/main/java/guesthouse/guestHousePost/dto/request/ChangeStatusRequest.java
@@ -1,0 +1,8 @@
+package guesthouse.guestHousePost.dto.request;
+
+import guesthouse.guestHousePost.domain.vo.Status;
+
+public record ChangeStatusRequest(
+        Status status
+) {
+}

--- a/src/main/java/guesthouse/guestHousePost/exception/GuestHousePostErrorCode.java
+++ b/src/main/java/guesthouse/guestHousePost/exception/GuestHousePostErrorCode.java
@@ -1,0 +1,36 @@
+package guesthouse.guestHousePost.exception;
+
+import guesthouse.common.exception.ErrorCode;
+
+public enum GuestHousePostErrorCode implements ErrorCode {
+
+    NOT_FOUND("게스트하우스 게시글이 존재하지 않습니다.", 404),
+    ;
+
+    private final String message;
+    private final int statusCode;
+
+    GuestHousePostErrorCode(String message, int statusCode) {
+        this.message = message;
+        this.statusCode = statusCode;
+    }
+
+    GuestHousePostErrorCode(String message) {
+        this(message, 400);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public int getStatus() {
+        return statusCode;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/guesthouse/guestHousePost/exception/GuestHousePostException.java
+++ b/src/main/java/guesthouse/guestHousePost/exception/GuestHousePostException.java
@@ -1,0 +1,12 @@
+package guesthouse.guestHousePost.exception;
+
+import guesthouse.common.exception.ErrorCode;
+import guesthouse.common.exception.GuestHouseException;
+
+public class GuestHousePostException extends GuestHouseException {
+
+    public GuestHousePostException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}
+

--- a/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepository.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepository.java
@@ -11,4 +11,5 @@ public interface GuestHousePostRepository extends JpaRepository<GuestHousePost, 
 
     List<GuestHousePost> findByOwnerId(Long ownerId);
 
+    boolean existsByOwnerIdAndId(Long userId, Long guestHousePostId);
 }

--- a/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepositoryImpl.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepositoryImpl.java
@@ -8,6 +8,7 @@ import guesthouse.guestHousePost.domain.model.GuestHousePost;
 import guesthouse.guestHousePost.domain.vo.*;
 import guesthouse.staffrecruitment.domain.vo.Region;
 import guesthouse.staffrecruitment.domain.vo.SortType;
+import guesthouse.staffrecruitment.domain.vo.Status;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
@@ -17,6 +18,7 @@ import static guesthouse.guestHousePost.domain.model.QAmenity.amenity;
 import static guesthouse.guestHousePost.domain.model.QGuestHousePost.guestHousePost;
 import static guesthouse.guestHousePost.domain.model.QParty.party;
 import static guesthouse.guestHousePost.domain.model.QRoom.room;
+import static guesthouse.staffrecruitment.domain.model.QStaffRecruitment.staffRecruitment;
 
 @RequiredArgsConstructor
 public class GuestHousePostRepositoryImpl implements GuestHousePostCustomRepository {
@@ -41,7 +43,8 @@ public class GuestHousePostRepositoryImpl implements GuestHousePostCustomReposit
                         headCountTypeIn(filter.getHeadCountTypes()),
                         partyTypeIn(filter.getPartyTypes()),
                         moodAllMatch(filter.getMoods()),
-                        amenityIn(filter.getAmenities())
+                        amenityIn(filter.getAmenities()),
+                        isActive()
                 )
                 .groupBy(guestHousePost.id)
                 .having(
@@ -104,6 +107,10 @@ public class GuestHousePostRepositoryImpl implements GuestHousePostCustomReposit
         return amenity.value.in(amenities);
     }
 
+    private BooleanExpression isActive() {
+        return staffRecruitment.status.eq(Status.ACTIVE);
+    }
+
 
     private BooleanExpression keywordContains(String keyword) {
         return keyword == null ? null : guestHousePost.guestHouseName.contains(keyword);
@@ -129,7 +136,8 @@ public class GuestHousePostRepositoryImpl implements GuestHousePostCustomReposit
     public List<GuestHousePost> findRandom(int count, Region region) {
         return jpaQueryFactory
                 .selectFrom(guestHousePost)
-                .where(guestHousePost.region.eq(region))
+                .where(guestHousePost.region.eq(region),
+                        isActive())
                 .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
                 .limit(count)
                 .fetch();

--- a/src/main/java/guesthouse/guestHousePost/service/GuestHouseMapper.java
+++ b/src/main/java/guesthouse/guestHousePost/service/GuestHouseMapper.java
@@ -2,6 +2,7 @@ package guesthouse.guestHousePost.service;
 
 import guesthouse.guestHousePost.domain.model.GuestHousePost;
 import guesthouse.guestHousePost.domain.vo.Contact;
+import guesthouse.guestHousePost.domain.vo.Status;
 import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
 import lombok.experimental.UtilityClass;
 import org.locationtech.jts.geom.Coordinate;
@@ -30,6 +31,7 @@ public class GuestHouseMapper {
                 .moods(request.moods())
                 .contact(createContact(contact))
                 .ownerMessage(request.ownerMessage())
+                .status(Status.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/guesthouse/guestHousePost/service/GuestHousePostService.java
+++ b/src/main/java/guesthouse/guestHousePost/service/GuestHousePostService.java
@@ -2,12 +2,16 @@ package guesthouse.guestHousePost.service;
 
 import guesthouse.guestHousePost.domain.model.*;
 import guesthouse.guestHousePost.domain.vo.GuestHouseFilter;
+import guesthouse.guestHousePost.domain.vo.Status;
 import guesthouse.guestHousePost.dto.*;
 import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
 import guesthouse.guestHousePost.dto.response.OwnerGuestHousePostDto;
 import guesthouse.guestHousePost.dto.response.OwnerGuestHousePostsResponse;
 import guesthouse.guestHousePost.repository.*;
+import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
 import guesthouse.staffrecruitment.domain.vo.Region;
+import guesthouse.staffrecruitment.exception.StaffRecruitmentErrorCode;
+import guesthouse.staffrecruitment.exception.StaffRecruitmentException;
 import guesthouse.wish.service.WishService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -197,6 +201,20 @@ public class GuestHousePostService {
                 .toList();
         List<OwnerGuestHousePostDto> dtos = OwnerGuestHousePostDto.of(guestHousePosts, imageUrls);
         return new OwnerGuestHousePostsResponse(dtos);
+    }
+
+    @Transactional
+    public void changeStatus(Status status, Long userId, Long guestHousePostId) {
+        GuestHousePost guestHousePost = getGuestHousePostById(guestHousePostId);
+
+        if (!existsByOwnerIdAndId(userId, guestHousePostId))
+            throw new StaffRecruitmentException(StaffRecruitmentErrorCode.NOT_FOUND);
+
+        guestHousePost.changeStatus(status);
+    }
+
+    public boolean existsByOwnerIdAndId(Long userId, Long guestHousePostId) {
+        return guestHousePostRepository.existsByOwnerIdAndId(userId, guestHousePostId);
     }
 
 }

--- a/src/main/java/guesthouse/guestHousePost/service/GuestHousePostService.java
+++ b/src/main/java/guesthouse/guestHousePost/service/GuestHousePostService.java
@@ -7,6 +7,8 @@ import guesthouse.guestHousePost.dto.*;
 import guesthouse.guestHousePost.dto.request.GuestHouseCreateRequest;
 import guesthouse.guestHousePost.dto.response.OwnerGuestHousePostDto;
 import guesthouse.guestHousePost.dto.response.OwnerGuestHousePostsResponse;
+import guesthouse.guestHousePost.exception.GuestHousePostErrorCode;
+import guesthouse.guestHousePost.exception.GuestHousePostException;
 import guesthouse.guestHousePost.repository.*;
 import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
 import guesthouse.staffrecruitment.domain.vo.Region;
@@ -208,7 +210,7 @@ public class GuestHousePostService {
         GuestHousePost guestHousePost = getGuestHousePostById(guestHousePostId);
 
         if (!existsByOwnerIdAndId(userId, guestHousePostId))
-            throw new StaffRecruitmentException(StaffRecruitmentErrorCode.NOT_FOUND);
+            throw new GuestHousePostException(GuestHousePostErrorCode.NOT_FOUND);
 
         guestHousePost.changeStatus(status);
     }

--- a/src/main/java/guesthouse/staffrecruitment/controller/StaffRecruitmentController.java
+++ b/src/main/java/guesthouse/staffrecruitment/controller/StaffRecruitmentController.java
@@ -4,6 +4,7 @@ import guesthouse.common.annotation.UserId;
 import guesthouse.guestHousePost.dto.response.OwnerGuestHousePostsResponse;
 import guesthouse.staffrecruitment.domain.vo.*;
 import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
+import guesthouse.staffrecruitment.dto.request.ChangeStatusRequest;
 import guesthouse.staffrecruitment.dto.request.StaffRecruitmentCreateRequest;
 import guesthouse.staffrecruitment.dto.response.*;
 import guesthouse.staffrecruitment.random.RandomStaffRecruitmentPostsResponse;
@@ -81,6 +82,16 @@ public class StaffRecruitmentController {
     public ResponseEntity<OwnerStaffRecruitmentPostsResponse> getOwnStaffRecruitmentPosts(@UserId Long userId) {
         OwnerStaffRecruitmentPostsResponse response = staffRecruitmentService.getOwnStaffRecruitmentPosts(userId);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> changeStatus(
+            @RequestBody ChangeStatusRequest changeStatusRequest,
+            @UserId Long userId,
+            @PathVariable("id") Long staffRecruitmentId
+    ) {
+        staffRecruitmentService.changeStatus(changeStatusRequest.status(), userId, staffRecruitmentId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitment.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitment.java
@@ -2,6 +2,7 @@ package guesthouse.staffrecruitment.domain.model;
 
 import guesthouse.common.domain.TimeEntity;
 import guesthouse.staffrecruitment.domain.vo.Region;
+import guesthouse.staffrecruitment.domain.vo.Status;
 import guesthouse.staffrecruitment.domain.vo.WorkingPeriod;
 import jakarta.persistence.*;
 import lombok.*;
@@ -53,6 +54,8 @@ public class StaffRecruitment extends TimeEntity {
 
     @Column(nullable = false)
     private int viewCount;
+
+    private Status status;
 
     public void plusViewCount() {
         this.viewCount += 1;

--- a/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitment.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/model/StaffRecruitment.java
@@ -55,9 +55,14 @@ public class StaffRecruitment extends TimeEntity {
     @Column(nullable = false)
     private int viewCount;
 
+    @Enumerated(EnumType.STRING)
     private Status status;
 
     public void plusViewCount() {
         this.viewCount += 1;
+    }
+
+    public void changeStatus(Status status) {
+        this.status = status;
     }
 }

--- a/src/main/java/guesthouse/staffrecruitment/domain/vo/Status.java
+++ b/src/main/java/guesthouse/staffrecruitment/domain/vo/Status.java
@@ -1,0 +1,6 @@
+package guesthouse.staffrecruitment.domain.vo;
+
+public enum Status {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/guesthouse/staffrecruitment/dto/request/ChangeStatusRequest.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/request/ChangeStatusRequest.java
@@ -1,0 +1,8 @@
+package guesthouse.staffrecruitment.dto.request;
+
+import guesthouse.staffrecruitment.domain.vo.Status;
+
+public record ChangeStatusRequest(
+        Status status
+) {
+}

--- a/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
+++ b/src/main/java/guesthouse/staffrecruitment/repository/StaffRecruitmentRepositoryImpl.java
@@ -36,7 +36,8 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
                         restDaysEq(filter.getRestDays()),
                         workingPeriodsIn(filter.getWorkingPeriods()),
                         workScheduleIn(filter.getWorkScheduleType()),
-                        keywordContains(filter.getKeyword())
+                        keywordContains(filter.getKeyword()),
+                        isActive()
                 )
                 .orderBy(orderBy(filter.getSortType()))
                 .offset(pageable.getOffset())
@@ -90,6 +91,10 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
         return staffRecruitmentJob.workDays.in(workDayValues);
     }
 
+    private BooleanExpression isActive() {
+        return staffRecruitment.status.eq(Status.ACTIVE);
+    }
+
 
     private OrderSpecifier<?> orderBy(SortType sortType) {
         return switch (sortType) {
@@ -104,7 +109,8 @@ public class StaffRecruitmentRepositoryImpl implements StaffRecruitmentCustomRep
     public List<StaffRecruitment> findRandom(int count, Region region) {
         return jpaQueryFactory
                 .selectFrom(staffRecruitment)
-                .where(staffRecruitment.region.eq(region))
+                .where(staffRecruitment.region.eq(region),
+                        isActive())
                 .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
                 .limit(count)
                 .fetch();

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentMapper.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentMapper.java
@@ -3,6 +3,7 @@ package guesthouse.staffrecruitment.service;
 import guesthouse.staffrecruitment.domain.model.Contact;
 import guesthouse.staffrecruitment.domain.model.Feature;
 import guesthouse.staffrecruitment.domain.model.StaffRecruitment;
+import guesthouse.staffrecruitment.domain.vo.Status;
 import guesthouse.staffrecruitment.dto.request.StaffRecruitmentCreateRequest;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -44,6 +45,7 @@ public final class StaffRecruitmentMapper {
                 .feature(createFeature(feature))
                 .content(introduction.content())
                 .ownerMessage(request.ownerMessage())
+                .status(Status.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentService.java
+++ b/src/main/java/guesthouse/staffrecruitment/service/StaffRecruitmentService.java
@@ -7,6 +7,7 @@ import guesthouse.staffrecruitment.domain.model.StaffRecruitmentQuestion;
 import guesthouse.staffrecruitment.domain.vo.Region;
 import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentFilter;
 import guesthouse.staffrecruitment.domain.vo.StaffRecruitmentImageType;
+import guesthouse.staffrecruitment.domain.vo.Status;
 import guesthouse.staffrecruitment.dto.StaffRecruitmentDetailsDTO;
 import guesthouse.staffrecruitment.dto.request.StaffRecruitmentCreateRequest;
 import guesthouse.staffrecruitment.dto.response.*;
@@ -181,4 +182,17 @@ public class StaffRecruitmentService {
     }
 
 
+    @Transactional
+    public void changeStatus(Status status, Long userId, Long staffRecruitmentId) {
+        StaffRecruitment staffRecruitment = getStaffRecruitmentById(staffRecruitmentId);
+
+        if (!existsByOwnerIdAndId(userId, staffRecruitmentId))
+            throw new StaffRecruitmentException(StaffRecruitmentErrorCode.NOT_FOUND);
+
+        staffRecruitment.changeStatus(status);
+    }
+
+    public boolean existsByOwnerIdAndId(Long userId, Long staffRecruitmentId) {
+        return staffRecruitmentRepository.existsByOwnerIdAndId(userId, staffRecruitmentId);
+    }
 }


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- `StaffRecruitment`, `GuestHousePost`에 `Status` 필드 추가
- 스탭 모집글, 게스트하우스 게시글 비활성화/활성화 API 구현

## 어떻게 작업했나요?
- 두 엔티티에 `Status` 필드를 추가하고, QueryDSL 부분에서도 `ACTIVE`된 글들만 조회되도록 수정하였습니다
- 스탭 모집글, 게스트하우스 게시글의 `Status`를 요청으로 들어오는 `Status`로 변경되도록 구현하였습니다. 

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?

## 기타 사항

## 관련 이슈

closes #65 

