### PR TITLE
[BE-41] refactor: GuestHousePostRepositoryImpl QueryDSL 메소드 오타 수정

### DIFF
--- a/src/main/java/guesthouse/application_record/domain/model/ApplicationRecord.java
+++ b/src/main/java/guesthouse/application_record/domain/model/ApplicationRecord.java
@@ -24,7 +24,7 @@ public class ApplicationRecord extends TimeEntity {
     private Long userId;
 
     @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String applicationSnapShot;
 
     @Column(nullable = false)

--- a/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepositoryImpl.java
+++ b/src/main/java/guesthouse/guestHousePost/repository/GuestHousePostRepositoryImpl.java
@@ -8,7 +8,6 @@ import guesthouse.guestHousePost.domain.model.GuestHousePost;
 import guesthouse.guestHousePost.domain.vo.*;
 import guesthouse.staffrecruitment.domain.vo.Region;
 import guesthouse.staffrecruitment.domain.vo.SortType;
-import guesthouse.staffrecruitment.domain.vo.Status;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 
@@ -18,7 +17,6 @@ import static guesthouse.guestHousePost.domain.model.QAmenity.amenity;
 import static guesthouse.guestHousePost.domain.model.QGuestHousePost.guestHousePost;
 import static guesthouse.guestHousePost.domain.model.QParty.party;
 import static guesthouse.guestHousePost.domain.model.QRoom.room;
-import static guesthouse.staffrecruitment.domain.model.QStaffRecruitment.staffRecruitment;
 
 @RequiredArgsConstructor
 public class GuestHousePostRepositoryImpl implements GuestHousePostCustomRepository {
@@ -108,7 +106,7 @@ public class GuestHousePostRepositoryImpl implements GuestHousePostCustomReposit
     }
 
     private BooleanExpression isActive() {
-        return staffRecruitment.status.eq(Status.ACTIVE);
+        return guestHousePost.status.eq(Status.ACTIVE);
     }
 
 

--- a/src/main/java/guesthouse/staffrecruitment/dto/request/StaffRecruitmentCreateRequest.java
+++ b/src/main/java/guesthouse/staffrecruitment/dto/request/StaffRecruitmentCreateRequest.java
@@ -70,7 +70,7 @@ public record StaffRecruitmentCreateRequest(
 
     public record WorkingInformation(
 
-            @NotBlank
+            @NotNull
             LocalDate startDate,
 
             @NotNull


### PR DESCRIPTION
## 작업한 내용은 무엇인가요?
- `GuestHousePostRepositoryImpl QueryDSL` 메소드 오타 수정
- `GuestHouseCreateRequest`의 LocalDate 타입 데이터에 대한 유효성 검사 어노테이션 수정 (`@NotNull`로)
- `ApplicationRecord`의 `applicationSnapShot`에 `TEXT` 옵션 추가

## 어떻게 작업했나요?

## 리뷰어가 중점적으로 봐야할부분은 무엇인가요?

## 기타 사항

## 관련 이슈

closes #79 
